### PR TITLE
support for type 6/10/12 CMAPs (and thus Unicode astral-plane characters)

### DIFF
--- a/lib/ttfunk/table/cmap.rb
+++ b/lib/ttfunk/table/cmap.rb
@@ -13,7 +13,9 @@ module TTFunk
       end
 
       def unicode
-        @unicode ||= @tables.select { |table| table.unicode? }
+        # Because most callers just call .first on the result, put tables with highest-number format first.
+        # (Tables with higher format numbers tend to be more complete, especially in higher/astral Unicode ranges.)
+        @unicode ||= @tables.select { |table| table.unicode? }.sort{|a,b| b.format <=> a.format }
       end
 
       private

--- a/lib/ttfunk/table/cmap/format06.rb
+++ b/lib/ttfunk/table/cmap/format06.rb
@@ -1,0 +1,51 @@
+module TTFunk
+  class Table
+    class Cmap
+
+      module Format06
+        attr_reader :language
+        attr_reader :code_map
+
+        def self.encode(charmap)
+          next_id = 0 
+          glyph_map = { 0 => 0 }
+
+          sorted_chars = charmap.keys.sort
+          low_char, high_char = sorted_chars.first, sorted_chars.last
+          entry_count = (1+high_char-low_char)
+          glyph_indexes = Array.new(entry_count, 0)
+
+          new_map = charmap.keys.sort.inject({}) do |map, code|
+            glyph_map[charmap[code]] ||= next_id += 1
+            map[code] = { :old => charmap[code], :new => glyph_map[charmap[code]] }
+            glyph_indexes[code - low_char] = glyph_map[charmap[code]]
+            map
+          end
+
+          subtable = [6, 10+entry_count*2, 0, low_char, entry_count, *glyph_indexes].pack('n*')
+
+          { :charmap => new_map, :subtable => subtable, :max_glyph_id => next_id+1 }
+        end
+
+        def [](code)
+          @code_map[code] || 0
+        end
+
+        def supported?
+          true
+        end
+
+        private
+          def parse_cmap!
+            length, @language, firstcode, entrycount = read(8, 'nnnn')
+            @code_map = {}
+            (firstcode...(firstcode+entrycount)).each do |code|
+              @code_map[code] = read(2, 'n').first & 0xFFFF
+            end
+          end
+
+      end
+
+    end
+  end
+end

--- a/lib/ttfunk/table/cmap/format10.rb
+++ b/lib/ttfunk/table/cmap/format10.rb
@@ -1,0 +1,52 @@
+module TTFunk
+  class Table
+    class Cmap
+
+      module Format10
+        attr_reader :language
+        attr_reader :code_map
+
+        def self.encode(charmap)
+          next_id = 0 
+          glyph_map = { 0 => 0 }
+
+          sorted_chars = charmap.keys.sort
+          low_char, high_char = sorted_chars.first, sorted_chars.last
+          entry_count = (1+high_char-low_char)
+          glyph_indexes = Array.new(entry_count, 0)
+
+          new_map = charmap.keys.sort.inject({}) do |map, code|
+            glyph_map[charmap[code]] ||= next_id += 1
+            map[code] = { :old => charmap[code], :new => glyph_map[charmap[code]] }
+            glyph_indexes[code - low_char] = glyph_map[charmap[code]]
+            map
+          end
+
+          subtable = [10, 0, 20+entry_count*4, 0, low_char, entry_count, *glyph_indexes].pack('nnN*')
+
+          { :charmap => new_map, :subtable => subtable, :max_glyph_id => next_id+1 }
+        end
+
+        def [](code)
+          @code_map[code] || 0
+        end
+
+        def supported?
+          true
+        end
+
+        private
+          def parse_cmap!
+            fractional_version, length, @language, firstcode, entrycount = read(18, 'nNNNN')
+            raise NotImplementedError, "cmap version 10.#{fractional_version} is not supported" if fractional_version != 0
+            @code_map = {}
+            (firstcode...(firstcode+entrycount)).each do |code|
+              @code_map[code] = read(2, 'n').first & 0xFFFF
+            end
+          end
+
+      end
+
+    end
+  end
+end

--- a/lib/ttfunk/table/cmap/format12.rb
+++ b/lib/ttfunk/table/cmap/format12.rb
@@ -1,0 +1,66 @@
+module TTFunk
+  class Table
+    class Cmap
+
+      module Format12
+        attr_reader :language
+        attr_reader :code_map
+
+        def self.encode(charmap)
+          next_id = 0 
+          glyph_map = { 0 => 0 }
+          range_firstglyphs, range_firstcodes, range_lengths = [], [], []
+          last_glyph = last_code = -999
+
+          new_map = charmap.keys.sort.inject({}) do |map, code|
+            glyph_map[charmap[code]] ||= next_id += 1
+            map[code] = { :old => charmap[code], :new => glyph_map[charmap[code]] }
+
+            if code > last_code+1 || glyph_map[charmap[code]] > last_glyph+1
+              range_firstcodes << code
+              range_firstglyphs << glyph_map[charmap[code]] 
+              range_lengths << 1
+            else
+              range_lengths.push(range_lengths.pop) + 1
+            end
+            last_code = code
+            last_glyph = glyph_map[charmap[code]]
+
+            map
+          end
+
+          subtable = [12, 0, 16+12*range_lengths.size, 0, range_lengths.size].pack('nnNNN')
+          range_lengths.each_with_index do |length, i|
+            firstglyph, firstcode = range_firstglyphs[i], range_firstcodes[i]
+            subtable << [firstcode, firstcode+length-1, firstglyph].pack('NNN')
+          end
+
+          { :charmap => new_map, :subtable => subtable, :max_glyph_id => next_id+1 }
+        end
+
+        def [](code)
+          @code_map[code] || 0
+        end
+
+        def supported?
+          true
+        end
+
+        private
+          def parse_cmap!
+            fractional_version, length, @language, groupcount = read(14, 'nNNN')
+            raise NotImplementedError, "cmap version 12.#{fractional_version} is not supported" if fractional_version != 0
+            @code_map = {}
+            (1..groupcount).each do
+              startchar, endchar, startglyph = read(12, 'NNN')
+              (0..(endchar-startchar)).each do |offset|
+                @code_map[startchar+offset] = startglyph+offset
+              end
+            end
+          end
+
+      end
+
+    end
+  end
+end

--- a/lib/ttfunk/table/cmap/subtable.rb
+++ b/lib/ttfunk/table/cmap/subtable.rb
@@ -13,7 +13,8 @@ module TTFunk
         ENCODING_MAPPINGS = {
           :mac_roman    => { :platform_id => 1, :encoding_id => 0 },
           # use microsoft unicode, instead of generic unicode, for optimal windows support
-          :unicode      => { :platform_id => 3, :encoding_id => 1 }
+          :unicode      => { :platform_id => 3, :encoding_id => 1 },
+          :unicode_ucs4 => { :platform_id => 3, :encoding_id => 10 }
         }
 
         def self.encode(charmap, encoding)
@@ -22,6 +23,8 @@ module TTFunk
             result = Format00.encode(charmap)
           when :unicode
             result = Format04.encode(charmap)
+          when :unicode_ucs4
+            result = Format12.encode(charmap)
           else
             raise NotImplementedError, "encoding #{encoding.inspect} is not supported"
           end
@@ -44,8 +47,11 @@ module TTFunk
             @format = read(2, "n").first
 
             case @format
-              when 0 then extend(TTFunk::Table::Cmap::Format00)
-              when 4 then extend(TTFunk::Table::Cmap::Format04)
+              when 0  then extend(TTFunk::Table::Cmap::Format00)
+              when 4  then extend(TTFunk::Table::Cmap::Format04)
+              when 6  then extend(TTFunk::Table::Cmap::Format06)
+              when 10 then extend(TTFunk::Table::Cmap::Format10)
+              when 12 then extend(TTFunk::Table::Cmap::Format12)
             end
 
             parse_cmap!
@@ -53,8 +59,8 @@ module TTFunk
         end
 
         def unicode?
-          platform_id == 3 && encoding_id == 1 && format == 4 ||
-          platform_id == 0 && format == 4
+          platform_id == 3 && (encoding_id == 1 || encoding_id == 10) && format != 0 ||
+          platform_id == 0 && format != 0
         end
 
         def supported?
@@ -77,3 +83,6 @@ end
 
 require 'ttfunk/table/cmap/format00'
 require 'ttfunk/table/cmap/format04'
+require 'ttfunk/table/cmap/format06'
+require 'ttfunk/table/cmap/format10'
+require 'ttfunk/table/cmap/format12'


### PR DESCRIPTION
Hello there,

I needed to create a document in Prawn using some astral-plane Unicode characters (i.e. ones with a codepoint larger than 16 bits), and noticed that this didn't work because TTFunk couldn't grok the relevant CMAP table in the font file.  So I added support for a few more modern CMAP format types, and this now works fine for me.

Cheers,
Rob
