### PR TITLE
add a missing require "pathnme"

### DIFF
--- a/lib/ttfunk.rb
+++ b/lib/ttfunk.rb
@@ -1,4 +1,5 @@
 require 'stringio'
+require 'pathname'
 require 'ttfunk/directory'
 require 'ttfunk/resource_file'
 


### PR DESCRIPTION
TTFunk::File.verify_and_open uses the Pathname keyword. Without this
require statement, one gets the following error

lib/ttfunk.rb:31:in `verify_and_open': uninitialized constant TTFunk::File::Pathname (NameError)

for example, when running the metrics.rb example.
