### PR TITLE
Consistent subset font names

### DIFF
--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -51,7 +51,7 @@ module TTFunk
         hhea_table = TTFunk::Table::Hhea.encode(original.horizontal_header, hmtx_table)
         maxp_table = TTFunk::Table::Maxp.encode(original.maximum_profile, old2new_glyph)
         post_table = TTFunk::Table::Post.encode(original.postscript, new2old_glyph)
-        name_table = TTFunk::Table::Name.encode(original.name)
+        name_table = TTFunk::Table::Name.encode(original.name, glyf_table[:table])
         head_table = TTFunk::Table::Head.encode(original.header, loca_table)
 
         # "optional" tables. Fonts may omit these if they do not need them. Because they

--- a/lib/ttfunk/table/name.rb
+++ b/lib/ttfunk/table/name.rb
@@ -1,4 +1,5 @@
 require_relative '../table'
+require 'digest/sha1'
 
 module TTFunk
   class Table
@@ -43,11 +44,8 @@ module TTFunk
       attr_reader :compatible_full
       attr_reader :sample_text
 
-      @@subset_tag = "AAAAAA"
-
-      def self.encode(names)
-        tag = @@subset_tag.dup
-        @@subset_tag.succ!
+      def self.encode(names, key = "")
+        tag = Digest::SHA1.hexdigest(key)[0, 6]
 
         postscript_name = Name::String.new("#{tag}+#{names.postscript_name}", 1, 0, 0)
 

--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "ttfunk/subset"
+
+describe "subsetting" do
+  it "consistently names font for same subsets" do
+    font = TTFunk::File.open test_font("DejaVuSans")
+
+    subset1 = TTFunk::Subset.for(font, :unicode)
+    subset1.use(97)
+    name1 = TTFunk::File.new(subset1.encode).name.strings[6]
+
+    subset2 = TTFunk::Subset.for(font, :unicode)
+    subset2.use(97)
+    name2 = TTFunk::File.new(subset2.encode).name.strings[6]
+
+    expect(name1).to eq name2
+  end
+
+  it "changes font names for different subsets" do
+    font = TTFunk::File.open test_font("DejaVuSans")
+
+    subset1 = TTFunk::Subset.for(font, :unicode)
+    subset1.use(97)
+    name1 = TTFunk::File.new(subset1.encode).name.strings[6]
+
+    subset2 = TTFunk::Subset.for(font, :unicode)
+    subset2.use(97)
+    subset2.use(98)
+    name2 = TTFunk::File.new(subset2.encode).name.strings[6]
+
+    expect(name1).to_not eq name2
+  end
+end


### PR DESCRIPTION
TTFunk used to generate semi-random subset font names. The name you'd get depended on the order/number of times you serialise your subsets.

Now subset font name only depends on the actual content of the subset.

As a bonus we're getting rid of a class var and as a result improve thread safety.