### PR TITLE
Move all requires to top level and use require instead of require_relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+* Use `require` instead of `require_relative` to avoid dual loading files
+
 ## [1.5.0] - 2017-02-13
 
 ### Added

--- a/lib/ttfunk.rb
+++ b/lib/ttfunk.rb
@@ -1,9 +1,9 @@
 require 'stringio'
 require 'pathname'
 
-require_relative 'ttfunk/directory'
-require_relative 'ttfunk/resource_file'
-require_relative 'ttfunk/collection'
+require 'ttfunk/directory'
+require 'ttfunk/resource_file'
+require 'ttfunk/collection'
 
 module TTFunk
   class File
@@ -119,15 +119,49 @@ module TTFunk
   end
 end
 
-require_relative 'ttfunk/table/cmap'
-require_relative 'ttfunk/table/glyf'
-require_relative 'ttfunk/table/head'
-require_relative 'ttfunk/table/hhea'
-require_relative 'ttfunk/table/hmtx'
-require_relative 'ttfunk/table/kern'
-require_relative 'ttfunk/table/loca'
-require_relative 'ttfunk/table/maxp'
-require_relative 'ttfunk/table/name'
-require_relative 'ttfunk/table/os2'
-require_relative 'ttfunk/table/post'
-require_relative 'ttfunk/table/sbix'
+require 'ttfunk/reader'
+require 'ttfunk/table'
+
+require 'ttfunk/table/cmap'
+require 'ttfunk/table/cmap/format00'
+require 'ttfunk/table/cmap/format04'
+require 'ttfunk/table/cmap/format06'
+require 'ttfunk/table/cmap/format10'
+require 'ttfunk/table/cmap/format12'
+require 'ttfunk/table/cmap/subtable'
+
+require 'ttfunk/table/glyf'
+require 'ttfunk/table/glyf/compound'
+require 'ttfunk/table/glyf/simple'
+
+require 'ttfunk/table/head'
+require 'ttfunk/table/hhea'
+require 'ttfunk/table/hmtx'
+
+require 'ttfunk/table/kern'
+require 'ttfunk/table/kern/format0'
+
+require 'ttfunk/table/loca'
+require 'ttfunk/table/maxp'
+require 'ttfunk/table/name'
+require 'ttfunk/table/os2'
+
+require 'ttfunk/table/post'
+require 'ttfunk/table/post/format10'
+require 'ttfunk/table/post/format20'
+require 'ttfunk/table/post/format30'
+require 'ttfunk/table/post/format40'
+
+require 'ttfunk/table/simple'
+require 'ttfunk/table/sbix'
+
+require 'ttfunk/encoding/mac_roman'
+require 'ttfunk/encoding/windows_1252'
+
+require 'ttfunk/subset'
+require 'ttfunk/subset/base'
+require 'ttfunk/subset/unicode'
+require 'ttfunk/subset/unicode_8bit'
+require 'ttfunk/subset/windows_1252'
+require 'ttfunk/subset/mac_roman'
+

--- a/lib/ttfunk/subset.rb
+++ b/lib/ttfunk/subset.rb
@@ -1,8 +1,3 @@
-require_relative 'subset/unicode'
-require_relative 'subset/unicode_8bit'
-require_relative 'subset/mac_roman'
-require_relative 'subset/windows_1252'
-
 module TTFunk
   module Subset
     def self.for(original, encoding)

--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -1,15 +1,3 @@
-require_relative '../table/cmap'
-require_relative '../table/glyf'
-require_relative '../table/head'
-require_relative '../table/hhea'
-require_relative '../table/hmtx'
-require_relative '../table/kern'
-require_relative '../table/loca'
-require_relative '../table/maxp'
-require_relative '../table/name'
-require_relative '../table/post'
-require_relative '../table/simple'
-
 module TTFunk
   module Subset
     class Base

--- a/lib/ttfunk/subset/mac_roman.rb
+++ b/lib/ttfunk/subset/mac_roman.rb
@@ -1,8 +1,5 @@
 require 'set'
 
-require_relative 'base'
-require_relative '../encoding/mac_roman'
-
 module TTFunk
   module Subset
     class MacRoman < Base

--- a/lib/ttfunk/subset/unicode.rb
+++ b/lib/ttfunk/subset/unicode.rb
@@ -1,5 +1,4 @@
 require 'set'
-require_relative 'base'
 
 module TTFunk
   module Subset

--- a/lib/ttfunk/subset/unicode_8bit.rb
+++ b/lib/ttfunk/subset/unicode_8bit.rb
@@ -1,5 +1,4 @@
 require 'set'
-require_relative 'base'
 
 module TTFunk
   module Subset

--- a/lib/ttfunk/subset/windows_1252.rb
+++ b/lib/ttfunk/subset/windows_1252.rb
@@ -1,8 +1,5 @@
 require 'set'
 
-require_relative 'base'
-require_relative '../encoding/windows_1252'
-
 module TTFunk
   module Subset
     class Windows1252 < Base

--- a/lib/ttfunk/subset_collection.rb
+++ b/lib/ttfunk/subset_collection.rb
@@ -1,5 +1,3 @@
-require_relative 'subset'
-
 module TTFunk
   class SubsetCollection
     def initialize(original)

--- a/lib/ttfunk/table.rb
+++ b/lib/ttfunk/table.rb
@@ -1,5 +1,3 @@
-require_relative 'reader'
-
 module TTFunk
   class Table
     include Reader

--- a/lib/ttfunk/table/cmap.rb
+++ b/lib/ttfunk/table/cmap.rb
@@ -33,5 +33,3 @@ module TTFunk
     end
   end
 end
-
-require_relative 'cmap/subtable'

--- a/lib/ttfunk/table/cmap/format00.rb
+++ b/lib/ttfunk/table/cmap/format00.rb
@@ -1,6 +1,3 @@
-require_relative '../../encoding/mac_roman'
-require_relative '../../encoding/windows_1252'
-
 module TTFunk
   class Table
     class Cmap

--- a/lib/ttfunk/table/cmap/subtable.rb
+++ b/lib/ttfunk/table/cmap/subtable.rb
@@ -1,5 +1,3 @@
-require_relative '../../reader'
-
 module TTFunk
   class Table
     class Cmap
@@ -87,9 +85,3 @@ module TTFunk
     end
   end
 end
-
-require_relative 'format00'
-require_relative 'format04'
-require_relative 'format06'
-require_relative 'format10'
-require_relative 'format12'

--- a/lib/ttfunk/table/glyf.rb
+++ b/lib/ttfunk/table/glyf.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Glyf < Table
@@ -61,6 +59,3 @@ module TTFunk
     end
   end
 end
-
-require_relative 'glyf/compound'
-require_relative 'glyf/simple'

--- a/lib/ttfunk/table/glyf/compound.rb
+++ b/lib/ttfunk/table/glyf/compound.rb
@@ -1,5 +1,3 @@
-require_relative '../../reader'
-
 module TTFunk
   class Table
     class Glyf

--- a/lib/ttfunk/table/glyf/simple.rb
+++ b/lib/ttfunk/table/glyf/simple.rb
@@ -1,5 +1,3 @@
-require_relative '../../reader'
-
 module TTFunk
   class Table
     class Glyf

--- a/lib/ttfunk/table/head.rb
+++ b/lib/ttfunk/table/head.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Head < TTFunk::Table

--- a/lib/ttfunk/table/hhea.rb
+++ b/lib/ttfunk/table/hhea.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Hhea < Table

--- a/lib/ttfunk/table/hmtx.rb
+++ b/lib/ttfunk/table/hmtx.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Hmtx < Table

--- a/lib/ttfunk/table/kern.rb
+++ b/lib/ttfunk/table/kern.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Kern < Table
@@ -84,5 +82,3 @@ module TTFunk
     end
   end
 end
-
-require_relative 'kern/format0'

--- a/lib/ttfunk/table/kern/format0.rb
+++ b/lib/ttfunk/table/kern/format0.rb
@@ -1,5 +1,3 @@
-require_relative '../../reader'
-
 module TTFunk
   class Table
     class Kern

--- a/lib/ttfunk/table/loca.rb
+++ b/lib/ttfunk/table/loca.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Loca < Table

--- a/lib/ttfunk/table/maxp.rb
+++ b/lib/ttfunk/table/maxp.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Maxp < Table

--- a/lib/ttfunk/table/name.rb
+++ b/lib/ttfunk/table/name.rb
@@ -1,4 +1,3 @@
-require_relative '../table'
 require 'digest/sha1'
 
 module TTFunk

--- a/lib/ttfunk/table/os2.rb
+++ b/lib/ttfunk/table/os2.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class OS2 < Table

--- a/lib/ttfunk/table/post.rb
+++ b/lib/ttfunk/table/post.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Post < Table
@@ -87,8 +85,3 @@ module TTFunk
     end
   end
 end
-
-require_relative 'post/format10'
-require_relative 'post/format20'
-require_relative 'post/format30'
-require_relative 'post/format40'

--- a/lib/ttfunk/table/post/format20.rb
+++ b/lib/ttfunk/table/post/format20.rb
@@ -1,4 +1,3 @@
-require_relative 'format10'
 require 'stringio'
 
 module TTFunk

--- a/lib/ttfunk/table/sbix.rb
+++ b/lib/ttfunk/table/sbix.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Sbix < Table

--- a/lib/ttfunk/table/simple.rb
+++ b/lib/ttfunk/table/simple.rb
@@ -1,5 +1,3 @@
-require_relative '../table'
-
 module TTFunk
   class Table
     class Simple < Table


### PR DESCRIPTION
Using `require_relative` can cause files to be loaded multiple times. An [example project](https://github.com/wconrad/rspec-duplicate-require) was created to show off this issue with rspec.

Here is the issue being exposed using prawn.
```
rrosenblum@C02NV0KSG3QN:~/work/test$ ls -la
total 32
drwxr-xr-x   8 rrosenblum  staff   272 Mar 18 14:12 .
drwxr-xr-x  44 rrosenblum  staff  1496 Mar 17 18:58 ..
drwxr-xr-x   3 rrosenblum  staff   102 Mar 17 18:59 .bundle
-rw-r--r--   1 rrosenblum  staff     6 Mar 17 18:58 .ruby-version
-rw-r--r--   1 rrosenblum  staff    52 Mar 18 14:12 Gemfile
-rw-r--r--   1 rrosenblum  staff   225 Mar 18 14:12 Gemfile.lock
drwxr-xr-x   3 rrosenblum  staff   102 Mar 17 18:59 vendor
lrwxr-xr-x   1 rrosenblum  staff     6 Mar 17 18:59 vendor2 -> vendor
rrosenblum@C02NV0KSG3QN:~/work/test$ cat Gemfile
source 'https://rubygems.org'

gem 'prawn', '2.2.2'
rrosenblum@C02NV0KSG3QN:~/work/test$ bundle config
Settings are listed in order of priority. The top value will be used.
jobs
Set for the current user (/Users/rrosenblum/.bundle/config): "3"

path
Set for your local app (/Users/rrosenblum/work/test/.bundle/config): "vendor2/bundle"
Set for the current user (/Users/rrosenblum/.bundle/config): "vendor/bundle"

disable_shared_gems
Set for your local app (/Users/rrosenblum/work/test/.bundle/config): "true"

rrosenblum@C02NV0KSG3QN:~/work/test$ bundle exec irb
irb(main):001:0> require 'prawn'
/Users/rrosenblum/work/test/vendor2/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:12: warning: already initialized constant PDF::Core::Text::VALID_OPTIONS
/Users/rrosenblum/work/test/vendor/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:12: warning: previous definition of VALID_OPTIONS was here
/Users/rrosenblum/work/test/vendor2/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:13: warning: already initialized constant PDF::Core::Text::MODES
/Users/rrosenblum/work/test/vendor/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:13: warning: previous definition of MODES was here
=> true
irb(main):002:0>
```