### PR TITLE
Fix Ruby Warnings

### DIFF
--- a/lib/ttfunk/table.rb
+++ b/lib/ttfunk/table.rb
@@ -10,6 +10,8 @@ module TTFunk
 
     def initialize(file)
       @file = file
+      @offset = nil
+      @length = nil
 
       info = file.directory_info(tag)
 


### PR DESCRIPTION
Here's a patch fixing the following Ruby warning:

```
lib/ruby/gems/2.4.0/gems/ttfunk-1.5.1/lib/ttfunk/table.rb:25: warning: instance variable @offset not initialized
```