### PR TITLE
Fix code style to pass CI building

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Include:
     - '**/Rakefile'
+    - '**/Gemfile'
     - '*.gemspec'
   Exclude:
     - 'pkg/**/*'

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-task default: [:rubocop, :spec]
+task default: %i[rubocop spec]
 
 desc 'Run all rspec files'
 RSpec::Core::RakeTask.new('spec')

--- a/examples/metrics.rb
+++ b/examples/metrics.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require_relative '../lib/ttfunk'
 
 def character_lookup(file, character)


### PR DESCRIPTION
Currently, the CI has failed with rubocop offences. Here's a patch fixing those offences.