### PR TITLE
Remove ruby 2.1 from CI, add 2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install:
   - gem install bundler
   - bundle --version
 rvm:
-  - 2.1.0-p0
-  - 2.1.10
   - 2.2.0-p0
   - 2.2.6
   - 2.3.0
   - 2.3.3
-  - 2.4.0-rc1
+  - 2.4.0
+  - 2.4.3
+  - 2.5.0
   - jruby-9.1.7.0


### PR DESCRIPTION
Ruby 2.1 is no longer maintained.

cf #46 