### PR TITLE
Fix typo in TTFunk::Subset::Unicode#includes?

### DIFF
--- a/lib/ttfunk/subset/unicode.rb
+++ b/lib/ttfunk/subset/unicode.rb
@@ -26,7 +26,7 @@ module TTFunk
       end
 
       def includes?(character)
-        @subset.includes(character)
+        @subset.include?(character)
       end
 
       def from_unicode(character)

--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -63,4 +63,18 @@ describe 'subsetting' do
     expect(entry_selector).to eq(expected_entry_selector)
     expect(range_shift).to eq(expected_range_shift)
   end
+
+  it 'knows which characters it includes' do
+    font = TTFunk::File.open test_font('DejaVuSans')
+    unicode = TTFunk::Subset.for(font, :unicode)
+    unicode_8bit = TTFunk::Subset.for(font, :unicode_8bit)
+    mac_roman = TTFunk::Subset.for(font, :mac_roman)
+    windows1252 = TTFunk::Subset.for(font, :windows_1252)
+
+    [unicode, unicode_8bit, mac_roman, windows1252].each do |subset|
+      expect(subset.includes?(97)).to be_falsey
+      subset.use(97)
+      expect(subset.includes?(97)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
The `TTFunk::Subset::Unicode#includes?(char)` method is trying to invoke `#includes(char)` on the underlying `Set` object, but `Set` does not respond to `#includes`.

This is most likely just a typo and should be using `#include?` instead.

**Testing**

To reproduce the issue:

```ruby
require 'ttfunk'
require 'ttfunk/subset'
font = TTFunk::File.open('myfont.ttf')
subset = TTFunk::Subset.for(font, :unicode)
subset.includes?(42)
```
The above fails with ``NoMethodError: undefined method `includes' for #<Set: {}>``.