### PR TITLE
Fix calculation of search_range for font subsets.

### DIFF
--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -106,8 +106,9 @@ module TTFunk
 
         tables.delete_if { |_tag, table| table.nil? }
 
-        search_range = (Math.log(tables.length) / Math.log(2)).to_i * 16
-        entry_selector = (Math.log(search_range) / Math.log(2)).to_i
+        max_pow2 = (Math.log(tables.length) / Math.log(2)).to_i
+        search_range = 2**max_pow2 * 16
+        entry_selector = max_pow2
         range_shift = tables.length * 16 - search_range
 
         newfont = [

--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 require 'ttfunk/subset'
 
 describe 'subsetting' do
@@ -35,5 +36,31 @@ describe 'subsetting' do
     font = TTFunk::File.open test_font('Mplus1p')
     subset1 = TTFunk::Subset.for(font, :unicode)
     expect { subset1.encode }.to_not raise_error
+  end
+
+  it 'calculates correct search_range, entry_selector and range_shift values' do
+    font = TTFunk::File.open test_font('DejaVuSans')
+
+    subset = TTFunk::Subset.for(font, :unicode)
+    subset.use(97)
+    subset_io = StringIO.new(subset.encode)
+
+    scaler_type, table_count = subset_io.read(6).unpack('Nn')
+    search_range, entry_selector, range_shift = subset_io.read(6).unpack('nnn')
+
+    # Subset fonts include 13 tables by default.
+    expected_table_count = 13
+    # Smallest power of two less than number of tables, times 16.
+    expected_search_range = 8 * 16
+    # Log2 of max power of two smaller than number of tables.
+    expected_entry_selector = 3
+    # Range shift is defined as 16*table_count - search_range.
+    expected_range_shift = 16 * expected_table_count - expected_search_range
+
+    expect(scaler_type).to eq(font.directory.scaler_type)
+    expect(table_count).to eq(expected_table_count)
+    expect(search_range).to eq(expected_search_range)
+    expect(entry_selector).to eq(expected_entry_selector)
+    expect(range_shift).to eq(expected_range_shift)
   end
 end


### PR DESCRIPTION
When encoding a font subset, the `search_range` field should be calculated as [`(maximum power of 2 <= numTables)*16`](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Directory).

Currently TTFunk is correctly calculating the maximum power of two (`2^x`), but then instead of setting `search_range` to the actual value of `2^x * 16`, it sets it to `x * 16`, which is not correct.

The incorrect entry for `search_range` causes the font to fail [OpenType Sanitizer (OTS)](https://github.com/khaledhosny/ots) validation. Because OTS is used in both Chrome and Firefox, the validation error means that the subset font generated with TTFunk currently cannot be used in the browser.

**Testing**

To reproduce the issue generate a new subset and save it to disk. Then run the OTS validator on it.

```ruby
require 'ttfunk'
require 'ttfunk/subset'
font = TTFunk::File.open('myfont.ttf')
subset = TTFunk::Subset.for(font, :unicode)
subset.use(97)
File.write('mysubset.ttf', subset.encode, mode: 'wb')
```

Install [OTS](https://github.com/khaledhosny/ots) and run `ots-sanitize`:

```bash
$ ots-sanitize mysubset.ttf
> ERROR at src/ots.cc:201 (ProcessTTF)
> WARNING: bad search range
> ERROR at src/ots.cc:207 (ProcessTTF)
> ERROR: incorrect entrySelector for table directory
> Failed to sanitize file!
```

**NOTE**

With this patch in place, `ots-sanitize` fails due to a different error, which will be fixed in a separate PR.