### PR TITLE
Order tables by tag when generating font subset.

### DIFF
--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -124,7 +124,9 @@ module TTFunk
 
         table_data = ''
         head_offset = nil
-        tables.each do |tag, data|
+        table_tags = tables.keys.sort
+        table_tags.each do |tag|
+          data = tables[tag]
           newfont << [tag, checksum(data), offset, data.length].pack('A4N*')
           table_data << data
           head_offset = offset if tag == 'head'

--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -38,6 +38,19 @@ describe 'subsetting' do
     expect { subset1.encode }.to_not raise_error
   end
 
+  it 'generates font directory with tables in ascending order' do
+    font = TTFunk::File.open test_font('DejaVuSans')
+
+    subset = TTFunk::Subset.for(font, :unicode)
+    subset.use(97)
+
+    directory = TTFunk::File.new(subset.encode).directory
+    table_tags = directory.tables.keys
+
+    expect(table_tags.sort).to eq(table_tags)
+    expect(table_tags.first).to be < table_tags.last
+  end
+
   it 'calculates correct search_range, entry_selector and range_shift values' do
     font = TTFunk::File.open test_font('DejaVuSans')
 


### PR DESCRIPTION
According to [the spec](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html#Directory), entries in the table directory must be sorted in ascending order by tag.

If the entries are not correctly sorted, OpenType Sanitizer check emits warnings, which can be seen in the browser console if font is used in browser which utilizes OTS (Chrome, Firefox).

**Testing**

To test this generate a new subset and save it to disk. Then run the OTS validator on it.

```ruby
require 'ttfunk'
require 'ttfunk/subset'
font = TTFunk::File.open('myfont.ttf')
subset = TTFunk::Subset.for(font, :unicode)
subset.use(97)
File.write('mysubset.ttf', subset.encode, mode: 'wb')
```

Install [OTS](https://github.com/khaledhosny/ots) and run `ots-sanitize`:

```bash
$ ots-sanitize mysubset.ttf
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR at src/ots.cc:578 (ProcessGeneric)
> WARNING: Table directory is not correctly ordered
> ERROR: cmap: Range glyph reference too high (65535 > 1)
> ERROR at src/cmap.cc:811 (Parse)
> ERROR at src/ots.cc:675 (ProcessGeneric)
> ERROR: cmap: Failed to parse table
> Failed to sanitize file!
```

**NOTE**: This assumes you already have the patch from #49 installed. The "Range glyph reference too high" issue will be fixed in a separate PR.