### PR TITLE
Map the 0xFFFF char code to glyph 0 in cmap format 4.

### DIFF
--- a/lib/ttfunk/table/cmap/format04.rb
+++ b/lib/ttfunk/table/cmap/format04.rb
@@ -47,7 +47,11 @@ module TTFunk
           offset = 0
           start_codes.zip(end_codes).each_with_index do |(a, b), segment|
             if a == 0xFFFF
-              deltas << 0
+              # We want the final 0xFFFF code to map to glyph 0.
+              # The glyph index is calculated as glyph = charcode + delta,
+              # which means that delta must be -0xFFFF to map character code
+              # 0xFFFF to glyph 0.
+              deltas << -0xFFFF
               range_offsets << 0
               break
             end

--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -90,4 +90,18 @@ describe 'subsetting' do
       expect(subset.includes?(97)).to be_truthy
     end
   end
+
+  it 'maps final code 0xFFFF to glyph 0 in generated type 4 cmap' do
+    font = TTFunk::File.open test_font('DejaVuSans')
+
+    subset = TTFunk::Subset.for(font, :unicode)
+    subset.use(97)
+    cmap = TTFunk::File.new(subset.encode).cmap
+
+    # Unicode subsets only contain a single format 4 cmap subtable.
+    expect(cmap.tables.size).to eq(1)
+    format04 = cmap.tables.first
+    expect(format04.format).to eq(4)
+    expect(format04.code_map[0xFFFF]).to eq(0)
+  end
 end


### PR DESCRIPTION
OpenType Sanitizer complains if the final code (`0xFFFF`) maps to a glyph index outside the range of glyphs in the subset.

[The spec](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html) suggests to map the code `0xFFFF` to glyph zero.

**Testing**:

To reproduce the issue generate a new subset and save it to disk. Then run the OTS validator on it.

```ruby
require 'ttfunk'
require 'ttfunk/subset'
font = TTFunk::File.open('myfont.ttf')
subset = TTFunk::Subset.for(font, :unicode)
subset.use(97)
File.write('mysubset.ttf', subset.encode, mode: 'wb')
```

Install [OTS](https://github.com/khaledhosny/ots) and run `ots-sanitize`:

```bash
$ ots-sanitize mysubset.ttf
> ERROR: cmap: Range glyph reference too high (65535 > 1)
> ERROR at src/cmap.cc:811 (Parse)
> ERROR at src/ots.cc:675 (ProcessGeneric)
> ERROR: cmap: Failed to parse table
> Failed to sanitize file!
```

**NOTE**: This assumes you have patches from #49 and #50 already installed, otherwise `ots-sanitize` fails with a different error.