### PR TITLE
Sort name table entries when generating subset font.

### DIFF
--- a/spec/integration/subset_spec.rb
+++ b/spec/integration/subset_spec.rb
@@ -104,4 +104,24 @@ describe 'subsetting' do
     expect(format04.format).to eq(4)
     expect(format04.code_map[0xFFFF]).to eq(0)
   end
+
+  it 'sorts records in the name table correctly' do
+    font = TTFunk::File.open test_font('DejaVuSans')
+
+    subset = TTFunk::Subset.for(font, :unicode)
+    subset.use(97)
+    name = TTFunk::File.new(subset.encode).name
+
+    records = []
+    name.entries.each do |entry|
+      records << [
+        entry[:platform_id],
+        entry[:encoding_id],
+        entry[:language_id],
+        entry[:name_id]
+      ]
+    end
+
+    expect(records).to eq(records.sort)
+  end
 end


### PR DESCRIPTION
Microsoft OpenType specification says that name records should be sorted by: platform_id, then platform_specific_id, then language_id, and finally by name_id.

The OpenType Sanitizer, which is used by browsers such as Chrome and Firefox to validate fonts before allowing them to be used in web pages, prints warnings if name records are not ordered.

**Testing**:

To reproduce the issue generate a new subset and save it to disk. Then run the OTS validator on it.

```ruby
require 'ttfunk'
require 'ttfunk/subset'
font = TTFunk::File.open('myfont.ttf')
subset = TTFunk::Subset.for(font, :unicode)
subset.use(97)
File.write('mysubset.ttf', subset.encode, mode: 'wb')
```

Install [OTS](https://github.com/khaledhosny/ots) and run `ots-sanitize`:

```bash
$ ots-sanitize mysubset.ttf
> WARNING: name: name records are not sorted.
> WARNING: name: name records are not sorted.
> WARNING: name: name records are not sorted.
> WARNING: name: name records are not sorted.
> WARNING: name: name records are not sorted.
> File sanitized successfully!
```

**NOTE**: This assumes you have patches from #49, #50, and #51 already installed, otherwise `ots-sanitize` fails with a different error.

With all #49, #50, #51, and this #52 patch in place, the generated subset font validates successfully \o/

```bash
$ ots-sanitize mysubset.ttf
> File sanitized successfully!
```