### PR TITLE
Minor fixes and small refactorings

### DIFF
--- a/lib/ttfunk/directory.rb
+++ b/lib/ttfunk/directory.rb
@@ -5,6 +5,10 @@ module TTFunk
 
     def initialize(io, offset = 0)
       io.seek(offset)
+
+      # https://www.microsoft.com/typography/otspec/otff.htm#offsetTable
+      # We're ignoring searchRange, entrySelector, and rangeShift here, but
+      # skipping past them to get to the table information.
       @scaler_type, table_count = io.read(12).unpack('Nn')
 
       @tables = {}

--- a/lib/ttfunk/encoding/mac_roman.rb
+++ b/lib/ttfunk/encoding/mac_roman.rb
@@ -1,8 +1,6 @@
 module TTFunk
   module Encoding
     class MacRoman
-      # rubocop: disable Layout/ExtraSpacing
-
       TO_UNICODE =
         Hash[*(0..255).zip(0..255).flatten]
         .update(
@@ -40,33 +38,6 @@ module TTFunk
         ).freeze
 
       FROM_UNICODE = TO_UNICODE.invert.freeze
-
-      # Maps MacRoman codes to their corresponding index in the Postscript glyph
-      # table (see TTFunk::Table::Post::Format10). If any entry in this array is
-      # a string, it is a postscript glyph that is not in the standard list, and
-      # which should be emitted specially in the TTF postscript table ('post',
-      # see format 2).
-      # rubocop: disable Metrics/LineLength,Layout/AlignArray,Layout/IndentArray
-      POSTSCRIPT_GLYPH_MAPPING = [
-          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, # 0x0F
-          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, # 0x1F
-          3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18, # 0x2F
-         19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34, # 0x3F
-         35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50, # 0x4F
-         51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  65,  66, # 0x5F
-         67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  81,  82, # 0x6F
-         83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,   0, # 0x7F
-         98,  99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, # 0x8F
-        114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, # 0x9F
-        130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, # 0xAF
-        146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, # 0xBF
-        162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, # 0xCF
-        178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 'Euro', 190, 191, 192, 193, # 0xDF
-        194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, # 0xEF
-        210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225  # 0xFF
-      ].freeze
-
-      # rubocop: enable Layout/AlignArray,Metrics/LineLength,Layout/ExtraSpacing,Layout/IndentArray
 
       def self.covers?(character)
         !FROM_UNICODE[character].nil?

--- a/lib/ttfunk/encoding/windows_1252.rb
+++ b/lib/ttfunk/encoding/windows_1252.rb
@@ -1,8 +1,6 @@
 module TTFunk
   module Encoding
     class Windows1252
-      # rubocop: disable Layout/ExtraSpacing
-
       TO_UNICODE =
         Hash[*(0..255).zip((0..255)).flatten]
         .update(
@@ -16,33 +14,6 @@ module TTFunk
         ).freeze
 
       FROM_UNICODE = TO_UNICODE.invert.freeze
-
-      # Maps Windows-1252 codes to their corresponding index in the Postscript
-      # glyph table (see TTFunk::Table::Post::Format10). If any entry in this
-      # array is a string, it is a postscript glyph that is not in the standard
-      # list, and which should be emitted specially in the TTF postscript table
-      # ('post', see format 2).
-      # rubocop: disable Metrics/LineLength,Layout/AlignArray,Layout/IndentArray
-      POSTSCRIPT_GLYPH_MAPPING = [
-          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-          3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,
-         19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,
-         35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,
-         51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  65,  66,
-         67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  81,  82,
-         83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,   0,
-     'Euro',   0, 196, 166, 197, 171, 130, 194, 216, 198, 228, 190, 176,   0, 230,   0,
-          0, 182, 183, 180, 181, 135, 178, 179, 217, 140, 229, 191, 177,   0, 231, 186,
-          3, 163, 132, 133, 189, 150, 232, 134, 142, 139, 157, 169, 164,  16, 138, 218,
-        131, 147, 242, 243, 141, 151, 136, 195, 222, 241, 158, 170, 245, 244, 246, 162,
-        173, 201, 199, 174,  98,  99, 144, 100, 203, 101, 200, 202, 207, 204, 205, 206,
-        233, 102, 211, 208, 209, 175, 103, 240, 145, 214, 212, 213, 104, 235, 237, 137,
-        106, 105, 107, 109, 108, 110, 160, 111, 113, 112, 114, 115, 117, 116, 118, 119,
-        234, 120, 122, 121, 123, 125, 124, 184, 161, 127, 126, 128, 129, 236, 238, 186
-      ].freeze
-
-      # rubocop: enable Layout/AlignArray,Metrics/LineLength,Layout/ExtraSpacing,Layout/IndentArray
 
       def self.covers?(character)
         !FROM_UNICODE[character].nil?

--- a/lib/ttfunk/table/cmap.rb
+++ b/lib/ttfunk/table/cmap.rb
@@ -24,10 +24,8 @@ module TTFunk
 
       def parse!
         @version, table_count = read(4, 'nn')
-        @tables = []
-
-        table_count.times do
-          @tables << Cmap::Subtable.new(file, offset)
+        @tables = Array.new(table_count) do
+          Cmap::Subtable.new(file, offset)
         end
       end
     end

--- a/lib/ttfunk/table/cmap/format04.rb
+++ b/lib/ttfunk/table/cmap/format04.rb
@@ -43,8 +43,8 @@ module TTFunk
           deltas = []
           range_offsets = []
           glyph_indices = []
-
           offset = 0
+
           start_codes.zip(end_codes).each_with_index do |(a, b), segment|
             if a == 0xFFFF
               # We want the final 0xFFFF code to map to glyph 0.
@@ -57,6 +57,7 @@ module TTFunk
             end
 
             start_glyph_id = new_map[a][:new]
+
             if a - start_glyph_id >= 0x8000
               deltas << 0
               range_offsets << 2 * (glyph_indices.length + segcount - segment)
@@ -65,6 +66,7 @@ module TTFunk
               deltas << -a + start_glyph_id
               range_offsets << 0
             end
+
             offset += 2
           end
 
@@ -120,7 +122,7 @@ module TTFunk
               else
                 index = id_range_offset[i] / 2 +
                   (code - start_code[i]) - (segcount - i)
-                # Decause some TTF fonts are broken
+                # Because some TTF fonts are broken
                 glyph_id = glyph_ids[index] || 0
                 glyph_id += id_delta[i] if glyph_id != 0
               end

--- a/lib/ttfunk/table/hmtx.rb
+++ b/lib/ttfunk/table/hmtx.rb
@@ -23,13 +23,18 @@ module TTFunk
 
       def for(glyph_id)
         @metrics[glyph_id] ||
-          HorizontalMetric.new(
-            @metrics.last.advance_width,
-            @left_side_bearings[glyph_id - @metrics.length]
-          )
+          metrics_cache[glyph_id] ||=
+            HorizontalMetric.new(
+              @metrics.last.advance_width,
+              @left_side_bearings[glyph_id - @metrics.length]
+            )
       end
 
       private
+
+      def metrics_cache
+        @metrics_cache ||= {}
+      end
 
       def parse!
         @metrics = []

--- a/lib/ttfunk/table/name.rb
+++ b/lib/ttfunk/table/name.rb
@@ -4,7 +4,7 @@ require 'digest/sha1'
 module TTFunk
   class Table
     class Name < Table
-      class String < ::String
+      class NameString < ::String
         attr_reader :platform_id
         attr_reader :encoding_id
         attr_reader :language_id
@@ -45,10 +45,30 @@ module TTFunk
       attr_reader :compatible_full
       attr_reader :sample_text
 
+      COPYRIGHT_NAME_ID = 0
+      FONT_FAMILY_NAME_ID = 1
+      FONT_SUBFAMILY_NAME_ID = 2
+      UNIQUE_SUBFAMILY_NAME_ID = 3
+      FONT_NAME_NAME_ID = 4
+      VERSION_NAME_ID = 5
+      POSTSCRIPT_NAME_NAME_ID = 6
+      TRADEMARK_NAME_ID = 7
+      MANUFACTURER_NAME_ID = 8
+      DESIGNER_NAME_ID = 9
+      DESCRIPTION_NAME_ID = 10
+      VENDOR_URL_NAME_ID = 11
+      DESIGNER_URL_NAME_ID = 12
+      LICENSE_NAME_ID = 13
+      LICENSE_URL_NAME_ID = 14
+      PREFERRED_FAMILY_NAME_ID = 16
+      PREFERRED_SUBFAMILY_NAME_ID = 17
+      COMPATIBLE_FULL_NAME_ID = 18
+      SAMPLE_TEXT_NAME_ID = 19
+
       def self.encode(names, key = '')
         tag = Digest::SHA1.hexdigest(key)[0, 6]
 
-        postscript_name = Name::String.new(
+        postscript_name = NameString.new(
           "#{tag}+#{names.postscript_name}", 1, 0, 0
         )
 
@@ -109,7 +129,7 @@ module TTFunk
         count.times do |i|
           io.pos = @entries[i][:offset]
           @entries[i][:text] = io.read(@entries[i][:length])
-          @strings[@entries[i][:name_id]] << Name::String.new(
+          @strings[@entries[i][:name_id]] << NameString.new(
             @entries[i][:text],
             @entries[i][:platform_id],
             @entries[i][:encoding_id],
@@ -117,26 +137,28 @@ module TTFunk
           )
         end
 
-        @copyright = @strings[0]
-        @font_family = @strings[1]
-        @font_subfamily = @strings[2]
-        @unique_subfamily = @strings[3]
-        @font_name = @strings[4]
-        @version = @strings[5]
         # should only be ONE postscript name
-        @postscript_name = @strings[6].first.strip_extended
-        @trademark = @strings[7]
-        @manufacturer = @strings[8]
-        @designer = @strings[9]
-        @description = @strings[10]
-        @vendor_url = @strings[11]
-        @designer_url = @strings[12]
-        @license = @strings[13]
-        @license_url = @strings[14]
-        @preferred_family = @strings[16]
-        @preferred_subfamily = @strings[17]
-        @compatible_full = @strings[18]
-        @sample_text = @strings[19]
+
+        @copyright = @strings[COPYRIGHT_NAME_ID]
+        @font_family = @strings[FONT_FAMILY_NAME_ID]
+        @font_subfamily = @strings[FONT_SUBFAMILY_NAME_ID]
+        @unique_subfamily = @strings[UNIQUE_SUBFAMILY_NAME_ID]
+        @font_name = @strings[FONT_NAME_NAME_ID]
+        @version = @strings[VERSION_NAME_ID]
+        @postscript_name = @strings[POSTSCRIPT_NAME_NAME_ID]
+                           .first.strip_extended
+        @trademark = @strings[TRADEMARK_NAME_ID]
+        @manufacturer = @strings[MANUFACTURER_NAME_ID]
+        @designer = @strings[DESIGNER_NAME_ID]
+        @description = @strings[DESCRIPTION_NAME_ID]
+        @vendor_url = @strings[VENDOR_URL_NAME_ID]
+        @designer_url = @strings[DESIGNER_URL_NAME_ID]
+        @license = @strings[LICENSE_NAME_ID]
+        @license_url = @strings[LICENSE_URL_NAME_ID]
+        @preferred_family = @strings[PREFERRED_FAMILY_NAME_ID]
+        @preferred_subfamily = @strings[PREFERRED_SUBFAMILY_NAME_ID]
+        @compatible_full = @strings[COMPATIBLE_FULL_NAME_ID]
+        @sample_text = @strings[SAMPLE_TEXT_NAME_ID]
       end
     end
   end


### PR DESCRIPTION
_**This pull request is part of a larger effort to bring OTF support to TTFunk. See https://github.com/prawnpdf/ttfunk/issues/53 for details.**_

Higlights of this PR:
1. Fix `Directory` so it parses the correct fields (I'm not even sure what `scaler_type` means or where it came from, I can't find it in any documentation).
2. Remove `POSTSCRIPT_GLYPH_MAPPING` constants from the Mac Roman and Windows 1252 subsets since they appear to not be used anywhere.
3. Take the head table's `index_to_loc_format` field into consideration when encoding.
4. Refactor the name table to be a little more object-oriented.