### PR TITLE
Support the DSIG table

### DIFF
--- a/lib/ttfunk.rb
+++ b/lib/ttfunk.rb
@@ -128,10 +128,18 @@ module TTFunk
           TTFunk::Table::Vorg.new(self)
         end
     end
+
+    def digital_signature
+      @digital_signature ||=
+        if directory.tables.include?(TTFunk::Table::Dsig::TAG)
+          TTFunk::Table::Dsig.new(self)
+        end
+    end
   end
 end
 
 require_relative 'ttfunk/table/cmap'
+require_relative 'ttfunk/table/dsig'
 require_relative 'ttfunk/table/glyf'
 require_relative 'ttfunk/table/head'
 require_relative 'ttfunk/table/hhea'

--- a/lib/ttfunk/table/dsig.rb
+++ b/lib/ttfunk/table/dsig.rb
@@ -1,0 +1,48 @@
+module TTFunk
+  class Table
+    class Dsig < Table
+      class SignatureRecord
+        attr_reader :format, :length, :offset, :signature
+
+        def initialize(format, length, offset, signature)
+          @format = format
+          @length = length
+          @offset = offset
+          @signature = signature
+        end
+      end
+
+      attr_reader :version, :flags, :signatures
+
+      TAG = 'DSIG'.freeze
+
+      def self.encode(dsig)
+        return nil unless dsig
+
+        # Don't attempt to re-sign or anything - just use dummy values.
+        # Since we're subsetting that should be permissible.
+        [dsig.version, 0, 0].pack('Nnn')
+      end
+
+      def tag
+        TAG
+      end
+
+      private
+
+      def parse!
+        @version, num_signatures, @flags = read(8, 'Nnn')
+
+        @signatures = Array.new(num_signatures) do
+          format, length, sig_offset = read(12, 'N3')
+          signature = parse_from(offset + sig_offset) do
+            _, _, sig_length = read(8, 'nnN')
+            read(sig_length, 'C*')
+          end
+
+          SignatureRecord.new(format, length, sig_offset, signature)
+        end
+      end
+    end
+  end
+end

--- a/lib/ttfunk/ttf_encoder.rb
+++ b/lib/ttfunk/ttf_encoder.rb
@@ -153,6 +153,12 @@ module TTFunk
       )
     end
 
+    def dsig_table
+      @dsig_table ||= TTFunk::Table::Dsig.encode(
+        original.digital_signature
+      )
+    end
+
     def tables
       @tables ||= {
         'cmap' => cmap_table[:table],
@@ -169,7 +175,8 @@ module TTFunk
         'prep' => prep_table,
         'fpgm' => fpgm_table,
         'cvt ' => cvt_table,
-        'VORG' => vorg_table
+        'VORG' => vorg_table,
+        'DSIG' => dsig_table
       }.reject { |_tag, table| table.nil? }
     end
 

--- a/spec/ttfunk/table/dsig_spec.rb
+++ b/spec/ttfunk/table/dsig_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'ttfunk/table/dsig'
+
+RSpec.describe TTFunk::Table::Dsig do
+  let(:font_path) { test_font('NotoSansCJKsc-Thin', :otf) }
+  let(:font) { TTFunk::File.open(font_path) }
+  let(:dsig_table) { font.digital_signature }
+
+  describe '.encode' do
+    let(:encoded) { described_class.encode(dsig_table) }
+    let(:reconstituted) do
+      described_class.new(TestFile.new(StringIO.new(encoded)))
+    end
+
+    it 'includes the same version information' do
+      expect(reconstituted.version).to eq(dsig_table.version)
+    end
+
+    it 'zeroes out the flags' do
+      expect(reconstituted.flags).to eq(0)
+    end
+
+    it 'removes all signature records' do
+      expect(reconstituted.signatures).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
_**This pull request is part of a larger effort to bring OTF support to TTFunk. See https://github.com/prawnpdf/ttfunk/issues/53 for details.**_

The only issue of note in this PR is that re-encoding the DSIG table will effectively remove all signatures from the font. Should we consider re-signing them with some TTFunk private key? My inclination is to not worry about it, at least for now.