### PR TITLE
Compute statistics for CFF fonts

### DIFF
--- a/lib/ttfunk.rb
+++ b/lib/ttfunk.rb
@@ -3,6 +3,7 @@
 require 'stringio'
 require 'pathname'
 
+require_relative 'ttfunk/aggregate'
 require_relative 'ttfunk/directory'
 require_relative 'ttfunk/resource_file'
 require_relative 'ttfunk/collection'
@@ -14,6 +15,9 @@ require_relative 'ttfunk/sci_form'
 require_relative 'ttfunk/bit_field'
 require_relative 'ttfunk/bin_utils'
 require_relative 'ttfunk/sub_table'
+require_relative 'ttfunk/min'
+require_relative 'ttfunk/max'
+require_relative 'ttfunk/sum'
 require_relative 'ttfunk/one_based_array'
 
 module TTFunk

--- a/lib/ttfunk.rb
+++ b/lib/ttfunk.rb
@@ -150,6 +150,14 @@ module TTFunk
           TTFunk::Table::Dsig.new(self)
         end
     end
+
+    def find_glyph(glyph_id)
+      if cff.exists?
+        cff.top_index[0].charstrings_index[glyph_id].glyph
+      else
+        glyph_outlines.for(glyph_id)
+      end
+    end
   end
 end
 

--- a/lib/ttfunk/aggregate.rb
+++ b/lib/ttfunk/aggregate.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TTFunk
+  class Aggregate
+    private
+
+    def coerce(other)
+      if other.respond_to?(:value_or)
+        other.value_or(0)
+      else
+        other
+      end
+    end
+  end
+end

--- a/lib/ttfunk/encoded_string.rb
+++ b/lib/ttfunk/encoded_string.rb
@@ -59,7 +59,7 @@ module TTFunk
     end
 
     def unresolved_string
-      io.string.force_encoding(Encoding::ASCII_8BIT)
+      io.string
     end
 
     def resolve_placeholder(name, value)

--- a/lib/ttfunk/max.rb
+++ b/lib/ttfunk/max.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TTFunk
+  class Max < Aggregate
+    attr_reader :value
+
+    def initialize(init_value = nil)
+      @value = init_value
+    end
+
+    def <<(new_value)
+      new_value = coerce(new_value)
+
+      if value.nil? || new_value > value
+        @value = new_value
+      end
+    end
+
+    def value_or(default)
+      return default if value.nil?
+
+      value
+    end
+  end
+end

--- a/lib/ttfunk/min.rb
+++ b/lib/ttfunk/min.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TTFunk
+  class Min < Aggregate
+    attr_reader :value
+
+    def initialize(init_value = nil)
+      @value = init_value
+    end
+
+    def <<(new_value)
+      new_value = coerce(new_value)
+
+      if value.nil? || new_value < value
+        @value = new_value
+      end
+    end
+
+    def value_or(default)
+      return default if value.nil?
+
+      value
+    end
+  end
+end

--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -15,6 +15,9 @@ require_relative '../table/simple'
 module TTFunk
   module Subset
     class Base
+      MICROSOFT_PLATFORM_ID = 3
+      MS_SYMBOL_ENCODING_ID = 0
+
       attr_reader :original
 
       def initialize(original)
@@ -23,6 +26,11 @@ module TTFunk
 
       def unicode?
         false
+      end
+
+      def microsoft_symbol?
+        new_cmap_table[:platform_id] == MICROSOFT_PLATFORM_ID &&
+          new_cmap_table[:encoding_id] == MS_SYMBOL_ENCODING_ID
       end
 
       def to_unicode_map

--- a/lib/ttfunk/subset/base.rb
+++ b/lib/ttfunk/subset/base.rb
@@ -33,14 +33,69 @@ module TTFunk
         encoder_klass.new(original, self, options).encode
       end
 
-      private
-
       def encoder_klass
         original.cff.exists? ? OTFEncoder : TTFEncoder
       end
 
       def unicode_cmap
         @unicode_cmap ||= @original.cmap.unicode.first
+      end
+
+      def glyphs
+        @glyphs ||= collect_glyphs(original_glyph_ids)
+      end
+
+      def collect_glyphs(glyph_ids)
+        collected = glyph_ids.each_with_object({}) do |id, h|
+          h[id] = glyph_for(id)
+        end
+
+        additional_ids = collected.values
+                                  .select { |g| g && g.compound? }
+                                  .map(&:glyph_ids)
+                                  .flatten
+
+        collected.update(collect_glyphs(additional_ids)) if additional_ids.any?
+
+        collected
+      end
+
+      def old_to_new_glyph
+        @old_to_new_glyph ||= begin
+          charmap = new_cmap_table[:charmap]
+          old_to_new = charmap.each_with_object(0 => 0) do |(_, ids), map|
+            map[ids[:old]] = ids[:new]
+          end
+
+          next_glyph_id = new_cmap_table[:max_glyph_id]
+
+          glyphs.keys.each do |old_id|
+            unless old_to_new.key?(old_id)
+              old_to_new[old_id] = next_glyph_id
+              next_glyph_id += 1
+            end
+          end
+
+          old_to_new
+        end
+      end
+
+      def new_to_old_glyph
+        @new_to_old_glyph ||= old_to_new_glyph.invert
+      end
+
+      private
+
+      def glyph_for(glyph_id)
+        if original.cff.exists?
+          original
+            .cff
+            .top_index[0]
+            .charstrings_index[glyph_id]
+            .glyph
+        else
+          original.glyph_outlines.for(glyph_id)
+        end
       end
     end
   end

--- a/lib/ttfunk/subset/code_page.rb
+++ b/lib/ttfunk/subset/code_page.rb
@@ -38,6 +38,7 @@ module TTFunk
         @code_page = code_page
         @encoding = encoding
         @subset = Array.new(256)
+        use(space_char_code)
       end
 
       def to_unicode_map
@@ -78,6 +79,10 @@ module TTFunk
       def original_glyph_ids
         ([0] + @subset.map { |unicode| unicode && unicode_cmap[unicode] })
           .compact.uniq.sort
+      end
+
+      def space_char_code
+        @space_char_code ||= from_unicode(Unicode::SPACE_CHAR)
       end
     end
   end

--- a/lib/ttfunk/subset/unicode.rb
+++ b/lib/ttfunk/subset/unicode.rb
@@ -6,9 +6,12 @@ require_relative 'base'
 module TTFunk
   module Subset
     class Unicode < Base
+      SPACE_CHAR = 0x20
+
       def initialize(original)
         super
         @subset = Set.new
+        use(SPACE_CHAR)
       end
 
       def unicode?

--- a/lib/ttfunk/sum.rb
+++ b/lib/ttfunk/sum.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module TTFunk
+  class Sum < Aggregate
+    attr_reader :value
+
+    def initialize(init_value = 0)
+      @value = init_value
+    end
+
+    def <<(operand)
+      @value += coerce(operand)
+    end
+
+    def value_or(_default)
+      # value should always be non-nil
+      value
+    end
+  end
+end

--- a/lib/ttfunk/table/cmap/subtable.rb
+++ b/lib/ttfunk/table/cmap/subtable.rb
@@ -36,14 +36,16 @@ module TTFunk
           mapping = ENCODING_MAPPINGS[encoding]
 
           # platform-id, encoding-id, offset
-          result[:subtable] = [
-            mapping[:platform_id],
-            mapping[:encoding_id],
-            12,
-            result[:subtable]
-          ].pack('nnNA*')
-
-          result
+          result.merge(
+            platform_id: mapping[:platform_id],
+            encoding_id: mapping[:encoding_id],
+            subtable: [
+              mapping[:platform_id],
+              mapping[:encoding_id],
+              12,
+              result[:subtable]
+            ].pack('nnNA*')
+          )
         end
 
         def initialize(file, table_start)

--- a/lib/ttfunk/table/glyf.rb
+++ b/lib/ttfunk/table/glyf.rb
@@ -41,14 +41,13 @@ module TTFunk
 
         parse_from(offset + index) do
           raw = io.read(size)
-          number_of_contours, x_min, y_min, x_max, y_max =
-            raw.unpack('n5').map { |i| to_signed(i) }
+          number_of_contours = to_signed(raw.unpack1('n'))
 
           @cache[glyph_id] =
             if number_of_contours == -1
-              Compound.new(raw, x_min, y_min, x_max, y_max)
+              Compound.new(glyph_id, raw)
             else
-              Simple.new(raw, number_of_contours, x_min, y_min, x_max, y_max)
+              Simple.new(glyph_id, raw)
             end
         end
       end

--- a/lib/ttfunk/table/glyf/path_based.rb
+++ b/lib/ttfunk/table/glyf/path_based.rb
@@ -33,6 +33,14 @@ module TTFunk
             @left_side_bearing -
             (@x_max - @x_min)
         end
+
+        def number_of_contours
+          path.number_of_contours
+        end
+
+        def compound?
+          false
+        end
       end
     end
   end

--- a/lib/ttfunk/table/maxp.rb
+++ b/lib/ttfunk/table/maxp.rb
@@ -24,21 +24,127 @@ module TTFunk
       attr_reader :max_component_elements
       attr_reader :max_component_depth
 
-      def self.encode(maxp, mapping)
-        ''.b.tap do |table|
-          num_glyphs = mapping.length
-          table << [maxp.version, num_glyphs].pack('Nn')
+      class << self
+        def encode(maxp, new2old_glyph)
+          ''.b.tap do |table|
+            num_glyphs = new2old_glyph.length
+            table << [maxp.version, num_glyphs].pack('Nn')
 
-          if maxp.version == 0x10000
-            table << [
-              maxp.max_points, maxp.max_contours, maxp.max_component_points,
-              maxp.max_component_contours, maxp.max_zones,
-              maxp.max_twilight_points, maxp.max_storage,
-              maxp.max_function_defs, maxp.max_instruction_defs,
-              maxp.max_stack_elements, maxp.max_size_of_instructions,
-              maxp.max_component_elements, maxp.max_component_depth
-            ].pack('n*')
+            if maxp.version == 0x10000
+              stats = stats_for(
+                maxp, glyphs_from_ids(maxp, new2old_glyph.values)
+              )
+
+              table << [
+                stats[:max_points],
+                stats[:max_contours],
+                stats[:max_component_points],
+                stats[:max_component_contours],
+                # these all come from the fpgm and cvt tables, which
+                # we don't support at the moment
+                maxp.max_zones,
+                maxp.max_twilight_points,
+                maxp.max_storage,
+                maxp.max_function_defs,
+                maxp.max_instruction_defs,
+                maxp.max_stack_elements,
+                stats[:max_size_of_instructions],
+                stats[:max_component_elements],
+                stats[:max_component_depth]
+              ].pack('n*')
+            end
           end
+        end
+
+        private
+
+        def glyphs_from_ids(maxp, glyph_ids)
+          glyph_ids.each_with_object([]) do |glyph_id, ret|
+            if (glyph = maxp.file.glyph_outlines.for(glyph_id))
+              ret << glyph
+            end
+          end
+        end
+
+        def stats_for(maxp, glyphs)
+          stats_for_simple(maxp, glyphs)
+            .merge(stats_for_compound(maxp, glyphs))
+            .each_with_object({}) do |(name, agg), ret|
+              ret[name] = agg.value_or(0)
+            end
+        end
+
+        def stats_for_simple(_maxp, glyphs)
+          max_component_elements = Max.new
+          max_points = Max.new
+          max_contours = Max.new
+          max_size_of_instructions = Max.new
+
+          glyphs.each do |glyph|
+            if glyph.compound?
+              max_component_elements << glyph.glyph_ids.size
+            else
+              max_points << glyph.end_point_of_last_contour
+              max_contours << glyph.number_of_contours
+              max_size_of_instructions << glyph.instruction_length
+            end
+          end
+
+          {
+            max_component_elements: max_component_elements,
+            max_points: max_points,
+            max_contours: max_contours,
+            max_size_of_instructions: max_size_of_instructions
+          }
+        end
+
+        def stats_for_compound(maxp, glyphs)
+          max_component_points = Max.new
+          max_component_depth = Max.new
+          max_component_contours = Max.new
+
+          glyphs.each do |glyph|
+            next unless glyph.compound?
+
+            stats = totals_for_compound(maxp, [glyph], 0)
+            max_component_points << stats[:total_points]
+            max_component_depth << stats[:max_depth]
+            max_component_contours << stats[:total_contours]
+          end
+
+          {
+            max_component_points: max_component_points,
+            max_component_depth: max_component_depth,
+            max_component_contours: max_component_contours
+          }
+        end
+
+        def totals_for_compound(maxp, glyphs, depth)
+          total_points = Sum.new
+          total_contours = Sum.new
+          max_depth = Max.new(depth)
+
+          glyphs.each do |glyph|
+            if glyph.compound?
+              stats = totals_for_compound(
+                maxp, glyphs_from_ids(maxp, glyph.glyph_ids), depth + 1
+              )
+
+              total_points << stats[:total_points]
+              total_contours << stats[:total_contours]
+              max_depth << stats[:max_depth]
+            else
+              stats = stats_for_simple(maxp, [glyph])
+              total_points << stats[:max_points]
+              total_contours << stats[:max_contours]
+            end
+          end
+
+          {
+            total_points: total_points,
+            total_contours: total_contours,
+            max_depth: max_depth
+          }
         end
       end
 

--- a/spec/ttfunk/ttf_encoder_spec.rb
+++ b/spec/ttfunk/ttf_encoder_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TTFunk::TTFEncoder do
 
       # verified via the Font-Validator tool at:
       # https://github.com/HinTak/Font-Validator
-      expect(checksum).to eq(0x6868CBB)
+      expect(checksum).to eq(0xF1AA96AB)
     end
   end
 end


### PR DESCRIPTION
_**This pull request is part of a larger effort to bring OTF support to TTFunk. See https://github.com/prawnpdf/ttfunk/issues/53 for details.**_

This PR augments TTFunk's ability to calculate font metrics for both postscript fonts (i.e. "normal" fonts) and CFF-flavored fonts. It updates the glyf, hhea, head, maxp, and os/2 tables specifically.