### PR TITLE
Fix maxp table encoding causing ghostscript error

### DIFF
--- a/lib/ttfunk/table/maxp.rb
+++ b/lib/ttfunk/table/maxp.rb
@@ -51,7 +51,7 @@ module TTFunk
                 stats[:max_size_of_instructions],
                 stats[:max_component_elements],
                 stats[:max_component_depth]
-              ].pack('n*')
+              ].pack('Nn*')
             end
           end
         end

--- a/spec/ttfunk/ttf_encoder_spec.rb
+++ b/spec/ttfunk/ttf_encoder_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TTFunk::TTFEncoder do
 
       # verified via the Font-Validator tool at:
       # https://github.com/HinTak/Font-Validator
-      expect(checksum).to eq(0xF1AA96AB)
+      expect(checksum).to eq(0xEAB69D71)
     end
   end
 end


### PR DESCRIPTION
See: https://github.com/prawnpdf/ttfunk/issues/53#issuecomment-570890100

I'm baffled as to how this got past FontValidator, but it did. In fact it turns out basically all our maxp calculations are wrong. Fortunately most font display systems don't care, but we should probably work on computing correct max profile statistics :/