### PR TITLE
Fix maxp table encoding

### DIFF
--- a/lib/ttfunk/table/maxp.rb
+++ b/lib/ttfunk/table/maxp.rb
@@ -51,7 +51,7 @@ module TTFunk
                 stats[:max_size_of_instructions],
                 stats[:max_component_elements],
                 stats[:max_component_depth]
-              ].pack('Nn*')
+              ].pack('n*')
             end
           end
         end

--- a/spec/ttfunk/ttf_encoder_spec.rb
+++ b/spec/ttfunk/ttf_encoder_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TTFunk::TTFEncoder do
 
       # verified via the Font-Validator tool at:
       # https://github.com/HinTak/Font-Validator
-      expect(checksum).to eq(0xEAB69D71)
+      expect(checksum).to eq(0xF1AA96AB)
     end
   end
 end


### PR DESCRIPTION
A wrong field size wash chosen for maxPoints. This shifted the rest of the fields and rendered the table invalid.

Fixes issues with 1.6.1 releases: #73, #74 

This does not resolve #72 

Adobe Acrobat does not complain about invalid fonts but still doesn't render special character (e.g. ö) correctly.