### PR TITLE
Allow TTC files to be read from IO object

### DIFF
--- a/lib/ttfunk/collection.rb
+++ b/lib/ttfunk/collection.rb
@@ -5,8 +5,14 @@ module TTFunk
     include Enumerable
 
     def self.open(path)
-      ::File.open(path, 'rb') do |io|
-        yield new(io)
+      if path.respond_to?(:read)
+        result = yield new(path)
+        path.rewind
+        result
+      else
+        ::File.open(path, 'rb') do |io|
+          yield new(io)
+        end
       end
     end
 

--- a/spec/integration/collection_spec.rb
+++ b/spec/integration/collection_spec.rb
@@ -22,7 +22,8 @@ describe TTFunk::Collection do
     it 'will open TTC files as IO' do
       success = false
 
-      described_class.open(StringIO.new(File.read(test_font('DejaVuSans', :ttc)))) do |_ttc|
+      io = StringIO.new(File.read(test_font('DejaVuSans', :ttc)))
+      described_class.open(io) do |_ttc|
         success = true
       end
 

--- a/spec/integration/collection_spec.rb
+++ b/spec/integration/collection_spec.rb
@@ -19,6 +19,16 @@ describe TTFunk::Collection do
       expect(success).to be true
     end
 
+    it 'will open TTC files as IO' do
+      success = false
+
+      described_class.open(StringIO.new(File.read(test_font('DejaVuSans', :ttc)))) do |_ttc|
+        success = true
+      end
+
+      expect(success).to be true
+    end
+
     it 'will report fonts in TTC' do
       described_class.open(test_font('DejaVuSans', :ttc)) do |ttc|
         expect(ttc.count).to eq 2


### PR DESCRIPTION
TTF files can already be read from an IO object, this pull request does the same for TTC files