### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') +
     ['CHANGELOG.md', 'README.md', 'COPYING', 'LICENSE', 'GPLv2', 'GPLv3']
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
   spec.add_development_dependency('rake', '~> 12')
   spec.add_development_dependency('rspec', '~> 3.5')
   spec.add_development_dependency('rubocop', '~> 0.68')


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.