### PR TITLE
Allow gem installation on ruby 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changes
+
+* Allow gem installation on Ruby 3.0
+
 ## [1.6.2.1]
 
 ### Fixed

--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') +
     ['CHANGELOG.md', 'README.md', 'COPYING', 'LICENSE', 'GPLv2', 'GPLv3']
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
   spec.add_development_dependency('rake', '~> 12')
   spec.add_development_dependency('rspec', '~> 3.5')
   spec.add_development_dependency('rubocop', '~> 0.68')


### PR DESCRIPTION
Ruby set to release v3.0 as usual in December of 2020
I think this gem should allow usage of ruby v3.0

Not sure if I should add some CI for ruby-head, since there maybe failures until stable release