### PR TITLE
Allow ruby 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
+  NewCops: disable
   TargetRubyVersion: 2.4
   Include:
     - '**/*.rb'
@@ -11,6 +12,9 @@ AllCops:
     - '*.gemspec'
   Exclude:
     - 'pkg/**/*'
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/lib/ttfunk/subset/code_page.rb
+++ b/lib/ttfunk/subset/code_page.rb
@@ -10,7 +10,6 @@ module TTFunk
       class << self
         def unicode_mapping_for(encoding)
           mapping_cache[encoding] ||= (0..255).each_with_object({}) do |c, ret|
-            # rubocop:disable Lint/SuppressedException
             begin
               ret[c] = c.chr(encoding)
                         .encode(Encoding::UTF_8)
@@ -20,7 +19,6 @@ module TTFunk
               # There is not a strict 1:1 mapping between all code page
               # characters and unicode.
             end
-            # rubocop:enable Lint/SuppressedException
           end
         end
 

--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') +
     ['CHANGELOG.md', 'README.md', 'COPYING', 'LICENSE', 'GPLv2', 'GPLv3']
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
   spec.add_development_dependency('rake', '~> 12')
   spec.add_development_dependency('rspec', '~> 3.5')
   spec.add_development_dependency('rubocop', '~> 0.68')


### PR DESCRIPTION
This is an alternative solution to allowing ruby 3.0 to @ShockwaveNN's approach.

I think shockwave's Rubocop update is still useful, and can still be merged. I took the approach of making the minimum changes to allow ruby 3.0 and keep CI green. Then we can resolve the new cops with @shockwaveNN's changes later. Shockwave can still follow up with docker changes if they like, but this unblocks ruby 3 first before doing any other CI changes.

cc/ @pointlessone