### PR TITLE
Reduce memory allocations and enhance performance

### DIFF
--- a/lib/ttfunk/subset/code_page.rb
+++ b/lib/ttfunk/subset/code_page.rb
@@ -34,6 +34,7 @@ module TTFunk
         @code_page = code_page
         @encoding = encoding
         @subset = Array.new(256)
+        @from_unicode_cache = {}
         use(space_char_code)
       end
 
@@ -55,7 +56,7 @@ module TTFunk
       end
 
       def from_unicode(character)
-        [character].pack('U*').encode(encoding).ord
+        @from_unicode_cache[character] ||= (+'' << character).encode!(encoding).ord
       rescue Encoding::UndefinedConversionError
         nil
       end

--- a/lib/ttfunk/subset_collection.rb
+++ b/lib/ttfunk/subset_collection.rb
@@ -17,12 +17,16 @@ module TTFunk
     def use(characters)
       characters.each do |char|
         covered = false
-        @subsets.each_with_index do |subset, _i|
-          next unless subset.covers?(char)
-
-          subset.use(char)
-          covered = true
-          break
+        i = 0
+        length = @subsets.length
+        while i < length
+          subset = @subsets[i]
+          if subset.covers?(char)
+            subset.use(char)
+            covered = true
+            break
+          end
+          i += 1
         end
 
         unless covered


### PR DESCRIPTION
I ran a benchmark using Prawn together with a TrueType font handled by
ttfunk which allocated a staggering 107 million objects (compared to 1.6
million objects for the same benchmark using HexaPDF).

A 5min investigation revealed two spots that when optimized reduced the
number to about 32 million objects.

* TTFunk::Subset::CodePage#from_unicode:

  Don't create an array and use #pack to convert a codepoint to a
  character, just add the codepoint directly, saving an array allocation.

  Furthermore, the created string can be modified using #encode! since
  it is thrown away anyway.

* TTFunk::SubsetCollection#use:

  The inner loop is called many times. By using a while loop instead of
  an iterator with a block we avoid allocating and calling the block.