### PR TITLE
Fixes #88 - created and modified are not parsed/encoded correctly

### DIFF
--- a/lib/ttfunk/table/head.rb
+++ b/lib/ttfunk/table/head.rb
@@ -26,8 +26,8 @@ module TTFunk
       # Long date time (used in TTF headers) is defined here:
       # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html
 
-      # January 1, 1904 00:00:00 UTC offset from Epoch
-      LDT_BASIS_OFFSET = 2_082_844_800
+      # January 1, 1904 00:00:00 UTC basis used by Long date time
+      LDT_BASIS = Time.new(1904, 1, 1, 0, 0, 0, 0).to_i
 
       class << self
         # mapping is new -> old glyph ids
@@ -48,11 +48,11 @@ module TTFunk
         end
 
         def from_ldt(ldt)
-          Time.at(ldt - LDT_BASIS_OFFSET).utc
+          Time.at(ldt + LDT_BASIS).utc
         end
 
         def to_ldt(time)
-          time.to_i + LDT_BASIS_OFFSET
+          time.to_i - LDT_BASIS
         end
 
         private

--- a/spec/ttfunk/table/head_spec.rb
+++ b/spec/ttfunk/table/head_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ttfunk/table/head'
+
+RSpec.describe TTFunk::Table::Head do
+  let(:font_path) { test_font('NotoSansCJKsc-Thin', :otf) }
+  let(:font) { TTFunk::File.open(font_path) }
+
+  describe '#created' do
+    it 'parses the field correctly' do
+      expect(font.header.created).to eq(Time.new(2015, 6, 15, 5, 5, 32, 0).utc)
+    end
+  end
+
+  describe '#modified' do
+    it 'parses the field correctly' do
+      expect(font.header.modified).to eq(Time.new(2015, 6, 15, 5, 5, 32, 0).utc)
+    end
+  end
+end


### PR DESCRIPTION
The created and modified values in the TTF header is a custom type called a long date time.  A definition can be found here:

https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html

The bytes are big endian encoded, and the basis is offset from standard Epoch.  To make these values at all useful in Ruby, they need to be properly decoded from bytes and then offset corrected to get a Time.  Similarly, we need to do the reverse transition when encoding in the header.

Fixes #88 

@gettalong and @pointlessone , a technical review would be helpful if you've got the time.  Thanks.