### PR TITLE
Bump up prawn_dev to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5.0"
-          - "2.5"
           - "2.6.0"
           - "2.6"
           - "2.7.0"
@@ -47,7 +45,7 @@ jobs:
           - "3.1.0"
           - "3.1"
           - ruby-head
-          - jruby-9.2
+          - jruby-9.3
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby

--- a/lib/ttfunk/table/cff/index.rb
+++ b/lib/ttfunk/table/cff/index.rb
@@ -81,7 +81,7 @@ module TTFunk
           when 2
             [offset].pack('n')
           when 3
-            [offset].pack('N')[1..-1]
+            [offset].pack('N')[1..]
           when 4
             [offset].pack('N')
           end

--- a/lib/ttfunk/table/cff/path.rb
+++ b/lib/ttfunk/table/cff/path.rb
@@ -60,7 +60,7 @@ module TTFunk
         private
 
         def format_values(command)
-          command[1..-1].map { |k| format('%.2f', k) }.join(' ')
+          command[1..].map { |k| format('%.2f', k) }.join(' ')
         end
       end
     end

--- a/lib/ttfunk/table/cff/top_dict.rb
+++ b/lib/ttfunk/table/cff/top_dict.rb
@@ -128,13 +128,11 @@ module TTFunk
         end
 
         def encoding
+          # PostScript type 1 fonts, i.e. CID fonts, i.e. some fonts that use
+          # the CFF table, don't specify an encoding, so this can be nil
           @encoding ||=
-            begin
-              # PostScript type 1 fonts, i.e. CID fonts, i.e. some fonts that use
-              # the CFF table, don't specify an encoding, so this can be nil
-              if (encoding_offset_or_id = self[OPERATORS[:encoding]])
-                Encoding.new(self, file, encoding_offset_or_id.first)
-              end
+            if (encoding_offset_or_id = self[OPERATORS[:encoding]])
+              Encoding.new(self, file, encoding_offset_or_id.first)
             end
         end
 

--- a/lib/ttfunk/table/kern.rb
+++ b/lib/ttfunk/table/kern.rb
@@ -52,7 +52,7 @@ module TTFunk
           version: version,
           length: length,
           coverage: coverage,
-          data: raw[10..-1],
+          data: raw[10..],
           vertical: (coverage & 0x1).zero?,
           minimum: (coverage & 0x2 != 0),
           cross: (coverage & 0x4 != 0),

--- a/spec/ttfunk/table/cff/charset_spec.rb
+++ b/spec/ttfunk/table/cff/charset_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TTFunk::Table::Cff::Charset do
         )
 
         # these should come from the strings index
-        expect(strings[-6..-1]).to eq(
+        expect(strings[-6..]).to eq(
           %w[
             endash.smcp emdash.smcp parenleft.alt parenright.alt
             parenleft.smcp parenright.smcp
@@ -72,7 +72,7 @@ RSpec.describe TTFunk::Table::Cff::Charset do
         )
 
         # these should come from the strings index
-        expect(strings[-6..-1]).to eq(
+        expect(strings[-6..]).to eq(
           %w[r_r s_s t_t w_w_w zero_seven zero_zero]
         )
       end
@@ -106,7 +106,7 @@ RSpec.describe TTFunk::Table::Cff::Charset do
         # font are Chinese characters which may not have useful descriptions.
         # For example, the Unicode/CLDR data for most Chinese characters simply
         # contains the description "CJK Ideograph."
-        expect(strings[-6..-1]).to eq(
+        expect(strings[-6..]).to eq(
           [nil, nil, nil, nil, nil, nil]
         )
       end

--- a/spec/ttfunk/table/cff/fd_selector_spec.rb
+++ b/spec/ttfunk/table/cff/fd_selector_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe TTFunk::Table::Cff::FdSelector do
         [15, 15, 15, 15, 15, 15, 15, 17, 17, 17, 17]
       )
 
-      expect(fd_indices[-10..-1]).to eq(
+      expect(fd_indices[-10..]).to eq(
         [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
       )
     end

--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') +
     ['CHANGELOG.md', 'README.md', 'COPYING', 'LICENSE', 'GPLv2', 'GPLv3']
-  spec.required_ruby_version = '>= 2.5'
-  spec.add_development_dependency('prawn-dev', '~> 0.2.0')
+  spec.required_ruby_version = '>= 2.6'
+  spec.add_development_dependency('prawn-dev', '~> 0.3.0')
 end


### PR DESCRIPTION
This PR bumps up prawn_dev to 0.3.0, which also bumps the minimum Ruby version to 2.6.0

It also:

1. Removes 2.5, 2.5.0, and jruby-9.2 from CI
2. Adds jruby-9.3 to CI
3. Addresses a few lints from the updated configuration