### PR TITLE
Improve the formatting of `font_revision` value

### DIFF
--- a/examples/metrics.rb
+++ b/examples/metrics.rb
@@ -26,7 +26,7 @@ file = TTFunk::File.open(file_name)
 
 puts '-- FONT ------------------------------------'
 
-puts format('revision  : %08x', file.header.font_revision)
+puts format('revision  : %.3f', file.header.font_revision.to_f / 65536)
 puts "name      : #{file.name.font_name.join(', ')}"
 puts "family    : #{file.name.font_family.join(', ')}"
 puts "subfamily : #{file.name.font_subfamily.join(', ')}"


### PR DESCRIPTION
A `header.font_revision` value of **72090** will now be displayed as **1.100** instead of **0001199a**, for example.