### PR TITLE
Allow bigdecimal **4.0.x** dependency for Ruby 4 compatibility

### DIFF
--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.7'
-  spec.add_runtime_dependency('bigdecimal', '~> 3.1')
+  spec.add_runtime_dependency('bigdecimal', '>= 3.1')
   spec.add_development_dependency('prawn-dev', '~> 0.4.0')
 end


### PR DESCRIPTION
- Change `bigdecimal` dependency from `~> 3.1` to `>= 3.1` in `ttfunk.gemspec`
- Resolves dependency conflicts when Ruby 4's standard library `bigdecimal` is present
- Maintains compatibility with `bigdecimal` **3.1.x** and **3.2.x** versions