### PR TITLE
Make bigdecimal an optional dependency

### DIFF
--- a/lib/ttfunk/table/cff/dict.rb
+++ b/lib/ttfunk/table/cff/dict.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'bigdecimal'
-
 module TTFunk
   class Table
     class Cff < TTFunk::Table
@@ -92,7 +90,7 @@ module TTFunk
           case operand
           when Integer
             encode_integer(operand)
-          when Float, BigDecimal
+          when Float, ->(op) { defined?(BigDecimal) && op.is_a?(BigDecimal) }
             encode_float(operand)
           when SciForm
             encode_sci(operand)
@@ -141,7 +139,11 @@ module TTFunk
         end
 
         def encode_significand(sig)
-          sig.to_s.each_char.with_object([]) do |char, ret|
+          if defined?(BigDecimal) && sig.is_a?(BigDecimal)
+            sig.to_s('F')
+          else
+            sig.to_s
+          end.each_char.with_object([]) do |char, ret|
             case char
             when '0'..'9'
               ret << Integer(char)

--- a/spec/ttfunk/table/cff/dict_spec.rb
+++ b/spec/ttfunk/table/cff/dict_spec.rb
@@ -106,4 +106,19 @@ RSpec.describe TTFunk::Table::Cff::Dict do
 
     expect(dict1.encode).to eq(dict2.encode)
   end
+
+  begin
+    require('bigdecimal')
+  rescue LoadError
+    # Ignore, it's OK if it's missing
+  end
+  if defined?(BigDecimal)
+    it 'encodes BigDecimal' do
+      dict = described_class.new(TestFile.new(StringIO.new('')), 0, 0)
+
+      dict[1] = BigDecimal('42')
+
+      expect(dict.encode).to eq("\x1EB\xA0\xFF\x01".b)
+    end
+  end
 end

--- a/ttfunk.gemspec
+++ b/ttfunk.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.7'
-  spec.add_dependency('bigdecimal', '~> 3.1')
+  spec.add_development_dependency('bigdecimal', '>= 3.1')
   spec.add_development_dependency('prawn-dev', '~> 0.6.0')
 end


### PR DESCRIPTION
Since we already support BigDecimal in CFF we'll keep it. That said, it seems like a very farfetched scenario. It doesn't lay in the re-encoding path. It can only be there by manually construction a CFF Dict which is a very specific an unconventionl thing to do. Anyway, since a BigDecimal can only come from the user code we'll leave it to the user to add the dependency.

This is an alternative solution to #108.