### PR TITLE
Fix CFF CID-keyed font subsetting: missing .notdef glyph and incorrect Charset encoding

### DIFF
--- a/lib/ttfunk/table/cff/charset.rb
+++ b/lib/ttfunk/table/cff/charset.rb
@@ -158,22 +158,30 @@ module TTFunk
               .sort_by { |mapping| mapping[:new] }
               .map { |mapping| sid_for(mapping[:old]) }
 
-          ranges = TTFunk::BinUtils.rangify(sids)
-          range_max = ranges.map(&:last).max
+          # BinUtils.rangify assumes a sorted sequence of values. In
+          # CID-keyed fonts, SIDs may not be in ascending order when
+          # sorted by new GID, which causes rangify to produce incorrect
+          # ranges. Fall back to array format if SIDs are not sorted.
+          sids_sorted = sids.each_cons(2).all? { |a, b| a <= b }
 
-          range_bytes =
-            if range_max.positive?
-              (Math.log2(range_max) / 8).floor + 1
-            else
-              # for cases when there are no sequences at all
-              Float::INFINITY
-            end
+          if sids_sorted
+            ranges = TTFunk::BinUtils.rangify(sids)
+            range_max = ranges.map(&:last).max
 
-          # calculate whether storing the charset as a series of ranges is
-          # more efficient (i.e. takes up less space) vs storing it as an
-          # array of SID values
-          total_range_size = (2 * ranges.size) + (range_bytes * ranges.size)
-          total_array_size = sids.size * element_width(:array_format)
+            range_bytes =
+              if range_max.positive?
+                (Math.log2(range_max) / 8).floor + 1
+              else
+                Float::INFINITY
+              end
+
+            total_range_size = (2 * ranges.size) + (range_bytes * ranges.size)
+            total_array_size = sids.size * element_width(:array_format)
+          else
+            # Force array format when SIDs are not sorted
+            total_range_size = Float::INFINITY
+            total_array_size = 0
+          end
 
           if total_array_size <= total_range_size
             ([format_int(:array_format)] + sids).pack('Cn*')

--- a/lib/ttfunk/table/cff/charstrings_index.rb
+++ b/lib/ttfunk/table/cff/charstrings_index.rb
@@ -26,10 +26,19 @@ module TTFunk
         end
 
         def encode_items(charmap)
-          charmap
+          new_items = charmap
             .reject { |code, mapping| mapping[:new].zero? && !code.zero? }
             .sort_by { |_code, mapping| mapping[:new] }
             .map { |(_code, mapping)| items[mapping[:old]] }
+
+          # Ensure .notdef (GID 0) is included in the CharstringsIndex.
+          # The charmap may not contain a mapping for .notdef, but the
+          # CFF spec requires .notdef to always be present at index 0.
+          unless charmap.any? { |code, mapping| mapping[:new].zero? && code.zero? }
+            new_items.unshift(items[0])
+          end
+
+          new_items
         end
 
         def font_dict_for(index)

--- a/lib/ttfunk/table/cff/fd_selector.rb
+++ b/lib/ttfunk/table/cff/fd_selector.rb
@@ -99,6 +99,14 @@ module TTFunk
               .sort_by { |_code, mapping| mapping[:new] }
               .map { |(_code, mapping)| [mapping[:new], self[mapping[:old]]] }
 
+          # Ensure .notdef (GID 0) is included in the FD selector.
+          # The charmap may not contain a mapping for .notdef, but the
+          # CharstringsIndex always includes .notdef at index 0, so the
+          # FD selector must have a corresponding entry for it.
+          unless new_indices.any? { |gid, _| gid.zero? }
+            new_indices.unshift([0, self[0]])
+          end
+
           ranges = rangify_gids(new_indices)
           total_range_size = ranges.size * RANGE_ENTRY_SIZE
           total_array_size = new_indices.size * ARRAY_ENTRY_SIZE

--- a/spec/ttfunk/table/cff/charset_spec.rb
+++ b/spec/ttfunk/table/cff/charset_spec.rb
@@ -162,5 +162,29 @@ RSpec.describe TTFunk::Table::Cff::Charset do
         expect(encoded.bytes).to eq([0x02, 0x00, 0x01, 0x03, 0xFF])
       end
     end
+
+    context 'when SIDs are not in ascending order' do
+      let(:charmap) do
+        # Simulate a CID-keyed font where GID order differs from SID order.
+        # SIDs in new GID order: [1, 10, 5, 8, 3] - not sorted.
+        {
+          0x20 => { old: 1, new: 1 },
+          0x21 => { old: 10, new: 2 },
+          0x22 => { old: 5, new: 3 },
+          0x23 => { old: 8, new: 4 },
+          0x24 => { old: 3, new: 5 },
+        }
+      end
+
+      it 'falls back to array format' do
+        expect(encoded.bytes[0]).to eq(0) # array format
+      end
+
+      it 'preserves the correct SID for each new GID' do
+        sids = encoded.bytes.drop(1).each_slice(2).map { |hi, lo| (hi << 8) | lo }
+        # SIDs should be in new GID order: [1, 10, 5, 8, 3]
+        expect(sids).to eq([1, 10, 5, 8, 3])
+      end
+    end
   end
 end

--- a/spec/ttfunk/table/cff/charstrings_index_spec.rb
+++ b/spec/ttfunk/table/cff/charstrings_index_spec.rb
@@ -174,4 +174,31 @@ RSpec.describe TTFunk::Table::Cff, 'Charstring Index' do # rubocop: disable RSpe
       ],
     )
   end
+
+  describe '#encode' do
+    let(:font_path) { test_font('NotoSansCJKsc-Thin', :otf) }
+
+    it 'includes .notdef at index 0 when charmap lacks GID 0' do
+      charmap = {
+        0x20 => { old: 1, new: 1 },
+        0x21 => { old: 2, new: 2 },
+      }
+
+      items = charstrings_index.__send__(:items)
+      encoded_items = charstrings_index.__send__(:encode_items, charmap)
+
+      # Should have 3 items: .notdef + 2 from charmap
+      expect(encoded_items.length).to eq(3)
+
+      # First item should be .notdef (items[0])
+      expect(encoded_items[0]).to eq(items[0])
+    end
+
+    it 'does not duplicate .notdef when charmap includes GID 0' do
+      charmap = (0..5).to_h { |i| [i, { old: i, new: i }] }
+      encoded_items = charstrings_index.__send__(:encode_items, charmap)
+
+      expect(encoded_items.length).to eq(6)
+    end
+  end
 end

--- a/spec/ttfunk/table/cff/fd_selector_spec.rb
+++ b/spec/ttfunk/table/cff/fd_selector_spec.rb
@@ -49,7 +49,20 @@ RSpec.describe TTFunk::Table::Cff::FdSelector do
         0x22 => { old: 3, new: 3 },
         0x24 => { old: 5, new: 5 },
       }
-      expect(fd_selector.encode(charmap)).to eq("\x00\x02\x04\x06")
+      expect(fd_selector.encode(charmap)).to eq("\x00\x01\x02\x04\x06")
+    end
+
+    it 'includes .notdef FD entry at index 0 when charmap lacks GID 0' do
+      charmap = {
+        0x20 => { old: 1, new: 1 },
+        0x22 => { old: 3, new: 3 },
+      }
+      result = fd_selector.encode(charmap)
+      # Format byte (0x00 = array) followed by FD indices.
+      # GID 0 (.notdef) should map to FD index of original GID 0,
+      # which is entries[0] = 1 in the test fixture.
+      expect(result.bytes[0]).to eq(0) # array format
+      expect(result.bytes[1]).to eq(1) # .notdef FD index
     end
   end
 


### PR DESCRIPTION
## Problem

When subsetting CID-keyed CFF fonts (e.g., NotoSerifCJK.ttc), the generated PDF contains corrupted glyph data, causing certain CJK characters to not render in PDF viewers. The issue was originally reported in prawnpdf/prawn#1105.

While the original crash (`NoMethodError` on `glyf` table) was resolved in ttfunk 1.8.0, the generated PDFs still contain structural errors in the CFF data that cause glyph rendering failures.

## Root Cause

Three related bugs in the CFF subsetting code:

### 1. `CharstringsIndex#encode_items` — missing .notdef charstring

When the charmap does not include a mapping for GID 0 (`.notdef`), the encoded CharstringsIndex omits the `.notdef` charstring. The CFF specification requires `.notdef` to always be present at index 0. This causes all charstring indices to be off by one.

### 2. `FdSelector#encode` — missing .notdef FD entry

Similarly, the encoded FD selector omits the entry for GID 0, causing a mismatch between charstring indices and their Font Dict assignments. Glyphs end up referencing the wrong Font Dict's local subroutines, producing corrupted outlines.

### 3. `Charset#encode` — incorrect range encoding for unsorted SIDs

In CID-keyed fonts, SIDs (String IDs) in new GID order are not necessarily in ascending order. `BinUtils.rangify` assumes sorted input and groups values where `b - a <= 1` into ranges. When SIDs decrease (e.g., `[1549, 1509]`), the difference is negative, which satisfies `<= 1`, causing unrelated SIDs to be incorrectly merged into a single range.

## Fix

- **CharstringsIndex**: Prepend the `.notdef` charstring (`items[0]`) when the charmap does not include GID 0.
- **FdSelector**: Prepend the `.notdef` FD entry (`[0, self[0]]`) when the charmap does not include GID 0.
- **Charset**: Check if SIDs are in ascending order before calling `rangify`. If not, fall back to array format encoding.

## Verification

- Tested with NotoSerifCJK.ttc (CID-keyed CFF font with 65,535 glyphs and 18 Font Dicts)
- All CJK characters render correctly in Chrome after the fix
- CFF structure validated with Python fonttools: all charstrings decompile and draw without errors
- FdSelector GID→FD mappings verified correct for all glyphs
- Charset CID names verified correct for all glyphs

## Reproduction
```ruby
require 'prawn'

Prawn::Document.new {
  font_families.update('NotoSerifCJK' => {
    normal: { file: '/path/to/NotoSerifCJK.ttc', font: 10 }
  })
  font 'NotoSerifCJK', size: 20
  text 'こんにちは世界テスト'
}.render_file 'output.pdf'
```

Before this fix, some characters (e.g., こ, 世, テ) are invisible in the output PDF. After this fix, all characters render correctly.

---

## 📎 Supplementary material

Supporting reference for *"Fix CFF CID-keyed font subsetting: missing `.notdef` glyph and incorrect Charset encoding."* All spec quotations are from **Adobe Technical Note #5176, "The Compact Font Format Specification"** (version 1.0, 4 December 2003); section names and table numbers are quoted verbatim, and conventional section numbers are given for convenience.

<details>
<summary><b>CFF spec references (Adobe TN #5176)</b></summary>

### Why `.notdef` must exist at index 0 — CharStrings INDEX

> **§14 CharStrings INDEX** "This contains the charstrings of all the glyphs in a font stored in an INDEX structure. Charstring objects contained within this INDEX are accessed by GID. **The first charstring (GID 0) must be the .notdef glyph.** The number of glyphs available in a font may be determined from the count field in the INDEX."

And, from the overview of how the parallel arrays line up (the *Charsets, Encodings and Glyphs* overview, immediately preceding §12 Encodings):

> "By definition the first glyph (GID 0) is '.notdef' and **must be present in all fonts**. Since this is always the case, it is not necessary to represent either the encoding (unencoded) or name (.notdef) for GID 0. Consequently, taking advantage of this optimization, the encoding and charset arrays always begin with GID 1."

**Takeaway for bug #1:** the CharStrings INDEX is the one place `.notdef` (GID 0) is *not* optional — it is required and occupies index 0. The charset/encoding arrays omit it (they start at GID 1), but the CharStrings INDEX does not. Dropping it shifts every subsequent charstring index by one.

### FDSelect structure — and the crucial difference from charset

> **§19 FDSelect** "The FDSelect associates an FD (Font DICT) with a glyph by specifying an FD index for that glyph. The FD index is used to access one of the Font DICTs stored in the Font DICT INDEX."

Format 0 (Table 27) — array, one byte per glyph:

| Type  | Name        | Description       |
|-------|-------------|-------------------|
| Card8 | format      | =0                |
| Card8 | fds[nGlyphs]| FD selector array |

> "Each element of the fd array (fds) represents the FD index of the corresponding glyph. … The number of glyphs (nGlyphs) is the value of the count field in the CharStrings INDEX. **(This format is identical to charset format 0 except that the .notdef glyph is included in this case.)**"

Format 3 (Table 28) — ranges:

| Type   | Name             | Description         |
|--------|------------------|---------------------|
| Card8  | format           | =3                  |
| Card16 | nRanges          | Number of ranges    |
| struct | Range3[nRanges]  | Range3 array (T.29) |
| Card16 | sentinel         | Sentinel GID        |

Range3 (Table 29): `Card16 first` ("First glyph index in range"), `Card8 fd` ("FD index for all glyphs in range").

> "Each Range3 describes a group of sequential GIDs that have the same FD index. … **The first range must have a 'first' GID of 0.** A sentinel GID follows the last range element … (The sentinel GID is set equal to the number of glyphs in the font. That is, its value is 1 greater than the last GID in the font.)"

**Takeaway for bug #2:** this is the exact spec sentence that makes #2 a real bug. The charset deliberately *omits* `.notdef`; the FDSelect deliberately *includes* it ("the .notdef glyph is included in this case", and Format 3's "first range must have a 'first' GID of 0"). Because the CharStrings INDEX has `.notdef` at GID 0, the FDSelect must carry a matching entry at GID 0, or the per-glyph FD lookup is shifted.

### Charset range-encoding formats

> **§13 Charsets** "Charset data is located via the offset operand to the **charset** operator in the Top DICT. Each charset is described by a format-type identifier byte followed by format-specific data. Three formats are currently defined as shown in Tables 17, 18, and 20."

Format 0 (Table 17) — array of SIDs:

| Type  | Name             | Description       |
|-------|------------------|-------------------|
| Card8 | format           | =0                |
| SID   | glyph[nGlyphs–1] | Glyph name array  |

> "… The number of glyphs (nGlyphs) is the value of the count field in the **CharStrings** INDEX. **(There is one less element in the glyph name array than nGlyphs because the .notdef glyph name is omitted.)**"

Format 1 (Table 18) → Range1 (Table 19):

| Type  | Name  | Description                            |
|-------|-------|----------------------------------------|
| SID   | first | First glyph in range                   |
| Card8 | nLeft | Glyphs left in range (excluding first) |

Format 2 (Table 20) → Range2 (Table 21):

| Type   | Name  | Description                            |
|--------|-------|----------------------------------------|
| SID    | first | First glyph in range                   |
| Card16 | nLeft | Glyphs left in range (excluding first) |

> "Each Range1 describes a group of sequential SIDs. … This format is particularly suited to charsets that are well ordered." "Format 2 differs from format 1 only in the size of the nLeft field … This format is most suitable for fonts with a large well-ordered charset — for example, for Asian CIDFonts."

And the reason subset CID fonts trip this — **§18 CID-keyed Fonts**:

> "The charset data, although in the same format as non-CIDFonts, will represent CIDs rather than SIDs … In a complete CIDFont the charset table will specify an identity mapping … **Subset CIDFonts will generally need to use a more complex charset table representing a non-identity mapping (where CID doesn't equal GID).**"

**Takeaway for bug #3:** the range formats encode `[first, nLeft]` where `nLeft` is a count of *sequential, ascending* SIDs ("glyphs left in range"). A non-identity subset charset is not ascending, so range encoding (and `BinUtils.rangify`, which assumes a sorted sequence) cannot represent it without corruption — array format (Format 0) must be used.

</details>

<details>
<summary><b>Before / after: GID → charstring-index mapping</b></summary>

In all three diagrams the example charmap **has no entry for GID 0** (the common case when subsetting — the consumer never asked for `.notdef`, so it isn't in the charmap). `items[n]` is the original font's charstring for original GID `n`.

### Bug #1 — `CharstringsIndex#encode_items`

charmap = `{0x20 => {old:1,new:1}, 0x21 => {old:2,new:2}}`

<table>
  <thead>
    <tr><th rowspan="2">new GID</th><th colspan="2">BEFORE (corrupt)</th><th colspan="2">AFTER (fixed)</th></tr>
    <tr><th>encoded charstring</th><th></th><th>encoded charstring</th><th></th></tr>
  </thead>
  <tbody>
    <tr><td>0</td><td><code>items[1]</code></td><td>❌</td><td><code>items[0]</code> = .notdef</td><td>✅</td></tr>
    <tr><td>1</td><td><code>items[2]</code></td><td>❌</td><td><code>items[1]</code> (old GID 1)</td><td>✅</td></tr>
    <tr><td>2</td><td><em>— dropped —</em></td><td>❌</td><td><code>items[2]</code> (old GID 2)</td><td>✅</td></tr>
  </tbody>
</table>

Without the prepend, index 0 is silently taken by the first *real* glyph, so the whole INDEX is shifted left by one and the last glyph falls off the end. Every consumer that looks up "new GID 1" gets original glyph 2's outline.

Fix: `new_items.unshift(items[0])` when the charmap has no GID 0.

### Bug #2 — `FdSelector#encode` (coupled to #1)

FDSelect (array format) is one FD-index byte **per glyph, starting at GID 0** (Table 27: "the .notdef glyph is included"). Once #1 puts `.notdef` at GID 0 in the CharStrings INDEX, FDSelect must have a matching entry at GID 0 or the two arrays drift apart. `self[old]` = the original glyph's FD index. (`fd(n)` below = FD index of original GID `n`.)

<table>
  <thead>
    <tr><th>new GID</th><th>CharStrings INDEX charstring (post #1)</th><th>FDSelect BEFORE (fd byte)</th><th></th><th>FDSelect AFTER (fd byte)</th><th></th></tr>
  </thead>
  <tbody>
    <tr><td>0</td><td>.notdef (<code>items[0]</code>)</td><td><code>fd(old 1)</code></td><td>❌</td><td><code>fd(old 0)</code></td><td>✅</td></tr>
    <tr><td>1</td><td><code>items[1]</code> (old 1)</td><td><code>fd(old 3)</code></td><td>❌</td><td><code>fd(old 1)</code></td><td>✅</td></tr>
    <tr><td>3</td><td><code>items[3]</code> (old 3)</td><td><em>— missing —</em></td><td>❌</td><td><code>fd(old 3)</code></td><td>✅</td></tr>
  </tbody>
</table>

Each glyph reads the FD index sitting one slot too early → wrong Font DICT → wrong **Private DICT / local subrs** → the charstring's `callsubr` operands resolve into a different subr INDEX → corrupt outline. This is exactly the "some CJK glyphs render as garbage / invisible" symptom.

Note the coupling: fixing #1 *without* #2 actually makes things worse for CID fonts, because #1 introduces the GID-0 slot in CharStrings that #2's entry is needed to align against. The two must land together.

Fix: `new_indices.unshift([0, self[0]])` when no GID-0 entry is present.

### Bug #3 — `Charset#encode` (range vs array)

For non-CID fonts SIDs sorted by new GID happen to be ascending, so `rangify` is safe. For a subset CID font they are not (see §18 quote above), and `rangify` mis-encodes — see the numerical walkthrough below. Before/after at the format level:

<table>
  <thead>
    <tr><th></th><th>BEFORE ❌</th><th>AFTER ✅</th></tr>
  </thead>
  <tbody>
    <tr><td>Decision</td><td>SIDs not ascending → rangify anyway → Range format chosen</td><td>SIDs not ascending → forced Array format 0</td></tr>
    <tr><td>Encoding</td><td>wrong <code>[first, nLeft]</code> ranges</td><td>SID-per-GID array</td></tr>
    <tr><td>Result</td><td>❌ wrong CIDs for some GIDs</td><td>✅ every CID preserved</td></tr>
  </tbody>
</table>

Fix: detect `sids.each_cons(2).all? { |a,b| a <= b }`; if not sorted, force array format (`total_range_size = ∞`, `total_array_size = 0`).

</details>

<details>
<summary><b><code>rangify</code> walkthrough (negative-difference corruption)</b></summary>

`BinUtils.rangify` (doc-commented "Turns a **(sorted)** sequence of values …"):

```ruby
def rangify(values)
  values
    .slice_when { |a, b| b - a > 1 }      # start a new range when the gap > 1
    .map { |span| [span.first, span.length - 1] }   # => [first, nLeft]
end
```

The output pairs are `[first_SID, nLeft]`, matching charset Range1/Range2 exactly (Tables 19/21: `first` + `nLeft` = "glyphs left in range, excluding first").

### The minimal failure: a single descending pair

`sids = [1549, 1509]`

- `slice_when` compares `(1549, 1509)`: predicate `b - a > 1` → `1509 - 1549 = -40`,
  and `-40 > 1` is **false** → **no split** → both stay in one span.
- map: `[span.first, span.length - 1]` = `[1549, 2 - 1]` = `[1549, 1]`.
- A decoder reads `first = 1549, nLeft = 1` → this range covers **SID 1549 and
  SID 1550**.

<table>
  <thead>
    <tr><th>new GID</th><th>intended SID</th><th>decoded SID</th><th></th></tr>
  </thead>
  <tbody>
    <tr><td>k</td><td>1549</td><td>1549</td><td>✅</td></tr>
    <tr><td>k+1</td><td>1509</td><td>1550</td><td>❌ 1509 lost; reader sees 1550</td></tr>
  </tbody>
</table>

The negative difference satisfies `<= 1`, so two unrelated SIDs are fused into one "sequential" range and the second glyph's CID is silently rewritten.

### Full example matching the regression test

`sids = [1, 10, 5, 8, 3]` (the SIDs in new-GID order from `charset_spec.rb`)

`rangify` step by step (`slice_when` starts a new slice **after** the pair where the predicate is true):

<table>
  <thead>
    <tr><th>pair</th><th>b − a</th><th>&gt; 1 ?</th><th>split here?</th></tr>
  </thead>
  <tbody>
    <tr><td>(1, 10)</td><td>9</td><td>yes</td><td>yes → close <code>[1]</code></td></tr>
    <tr><td>(10, 5)</td><td>−5</td><td>no</td><td>no → keep <code>10,5</code> together</td></tr>
    <tr><td>(5, 8)</td><td>3</td><td>yes</td><td>yes → close <code>[10, 5]</code></td></tr>
    <tr><td>(8, 3)</td><td>−5</td><td>no</td><td>no → keep <code>8,3</code> together</td></tr>
  </tbody>
</table>

Spans: `[1]`, `[10, 5]`, `[8, 3]` → ranges `[[1, 0], [10, 1], [8, 1]]`

Decoded back as charset ranges `(first, nLeft)`:

<table>
  <thead>
    <tr><th>range</th><th>covers (first … first+nLeft)</th><th>assigned to GIDs</th><th>result</th></tr>
  </thead>
  <tbody>
    <tr><td><code>[1, 0]</code></td><td>SID 1</td><td>GID 1</td><td>✅</td></tr>
    <tr><td><code>[10, 1]</code></td><td>SID 10, SID 11</td><td>GID 2, GID 3</td><td>❌ GID 3 → 11, want 5</td></tr>
    <tr><td><code>[8, 1]</code></td><td>SID 8, SID 9</td><td>GID 4, GID 5</td><td>❌ GID 5 → 9, want 3</td></tr>
  </tbody>
</table>

<table>
  <thead>
    <tr><th>new GID</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th></tr>
  </thead>
  <tbody>
    <tr><td>want</td><td>1</td><td>10</td><td>5</td><td>8</td><td>3</td></tr>
    <tr><td>rangify</td><td>1</td><td>10</td><td>❌ 11</td><td>8</td><td>❌ 9</td></tr>
  </tbody>
</table>

GID 3 and GID 5 are corrupted.

Cost check that makes BEFORE actually pick the broken encoding:
- `range_max = max(0, 1, 1) = 1` → `range_bytes = (log2(1)/8).floor + 1 = 1` →
  range_format8.
- `total_range_size = 2*3 + 1*3 = 9`; `total_array_size = 5 * 2 = 10`.
- `total_array_size (10) <= total_range_size (9)` → **false** → range format is
  chosen → corruption ships.

AFTER the fix: `sids_sorted` is false → `total_range_size = ∞`, `total_array_size = 0` → array format → encoded bytes `00 | 0001 000A 0005 0008 0003` → decoded SIDs `[1, 10, 5, 8, 3]` exactly. Matches the new spec: `encoded.bytes[0] == 0` (array format) and the round-tripped SIDs equal the input.

</details>

<sub>Section *names* and all *table numbers / quotations* above are transcribed directly from TN #5176. The conventional section numbers used (12 Encodings, 13 Charsets, 14 CharStrings INDEX, 18 CID-keyed Fonts, 19 FDSelect) are the standard numbering of the 2003 spec; if the published comment needs to be airtight, cite by table number (17–22 for charset, 27–29 for FDSelect), which is unambiguous.</sub>