### PR TITLE
Fix typos in README and source comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Github users who have at least one patch accepted to TTFunk.
 TTFunk is maintained as a dependency of Prawn, the ruby PDF generation library.
 
 Any questions or feedback should be sent to the [Prawn
-Diccussions](https://github.com/orgs/prawnpdf/discussions) group.
+Discussions](https://github.com/orgs/prawnpdf/discussions) group.

--- a/lib/ttfunk/sub_table.rb
+++ b/lib/ttfunk/sub_table.rb
@@ -19,7 +19,7 @@ module TTFunk
     # @return [Integer]
     attr_reader :table_offset
 
-    # This sub-table's length in byes.
+    # This sub-table's length in bytes.
     # @return [Integer, nil]
     attr_reader :length
 

--- a/lib/ttfunk/table.rb
+++ b/lib/ttfunk/table.rb
@@ -15,7 +15,7 @@ module TTFunk
     # @return [Integer]
     attr_reader :offset
 
-    # This table's length in byes.
+    # This table's length in bytes.
     # @return [Integer, nil]
     attr_reader :length
 


### PR DESCRIPTION
- `README.md`: "Diccussions" → "Discussions"
- `lib/ttfunk/table.rb`: "in byes" → "in bytes"
- `lib/ttfunk/sub_table.rb`: "in byes" → "in bytes"